### PR TITLE
v2.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# v2.1.4
+
+### Certificates
+
+#### Fixes
+* b0d1a49 fix(certificates): `keyfactor_certificate` data and resource types will not store auto password used to recover private key. `auto_password` has been removed from schema and state.
+* b0d1a49 fix(certificates): `keyfactor_certificate` resource type will no longer trigger replacement if `key_password` is changed. #74 #79 #80
+* b0d1a49 fix(certificates): When looking up a certificate by CN, `IncludeHasPrivateKey` is now included in the call to the Command API.
+* b0d1a49 fix(certificates): `keyfactor_certificate` resource updates `ca_cert` use correct field.
+* b0d1a49 fix(certificates): `keyfactor_certificate` resource updates `key_password` will now use plan value.
+* b0d1a49 fix(certificates): `keyfactor_certificate` resource updates `certificate_id` field now included using state value.
+* b0d1a49 fix(certificates): When sorting SAN lists, if length varies don't even try to sort as there is obviously a change and replacement must be triggered.
+
 # v2.1.3
 ### Certificates
 

--- a/docs/data-sources/certificate.md
+++ b/docs/data-sources/certificate.md
@@ -60,12 +60,11 @@ data "keyfactor_certificate" "cert_wo_pkey_id" {
 ### Optional
 
 - `collection_id` (Number) Optional certificate collection identifier used to ensure user access to the certificate.
-- `key_password` (String, Sensitive) Optional, this is used to fetch the private key from Keyfactor Command, iff Command was used to generate the certificate.
+- `key_password` (String, Sensitive) Password used to recover the private key from Keyfactor Command. NOTE: If no value is provided a random password will be generated for key recovery. This value is not stored and does not encrypt the private key in Terraform state.
 - `metadata` (Map of String) Metadata key-value pairs to be attached to certificate
 
 ### Read-Only
 
-- `auto_password` (String, Sensitive) Auto generated key password
 - `ca_certificate` (String) PEM formatted CA certificate
 - `certificate_authority` (String) Name of certificate authority (CA) to deploy certificate with Ex: Example Company CA 1
 - `certificate_chain` (String) PEM formatted full certificate chain

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -93,7 +93,7 @@ resource "keyfactor_certificate" "kf_csr_cert" {
 - `csr` (String) Base-64 encoded certificate signing request (CSR)
 - `dns_sans` (List of String) List of DNS names to use as subjects of the certificate. NOTE: Because changes to this field trigger replacement, use Terraform's `sort()` function to ensure consistent ordering of the list.
 - `ip_sans` (List of String) List of DNS names to use as subjects of the certificate. NOTE: Because changes to this field trigger replacement, use Terraform's `sort()` function to ensure consistent ordering of the list.
-- `key_password` (String, Sensitive) Password to protect certificate and private key with
+- `key_password` (String, Sensitive) Password used to recover the private key from Keyfactor Command. NOTE: If no value is provided a random password will be generated for key recovery. This value is not stored and does not encrypt the private key in Terraform state. Also note that if a password is provided it must meet any password complexity requirements enforced by the CA template or creation will fail. Auto-generated passwords will be of length 32 and contain a minimum of 4 of the following: uppercase, lowercase, numeric, and special characters.
 - `locality` (String) Subject locality (L) of the certificate
 - `metadata` (Map of String) Metadata key-value pairs to be attached to certificate
 - `organization` (String) Subject organization (O) of the certificate
@@ -103,7 +103,6 @@ resource "keyfactor_certificate" "kf_csr_cert" {
 
 ### Read-Only
 
-- `auto_password` (String, Sensitive) Password to protect certificate and private key with
 - `ca_certificate` (String) PEM formatted CA certificate
 - `certificate_chain` (String) PEM formatted full certificate chain
 - `certificate_id` (Number) Keyfactor Command certificate ID.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/keyfactor-pub/terraform-provider-keyfactor
 go 1.18
 
 require (
-	github.com/Keyfactor/keyfactor-go-client/v2 v2.1.1
+	github.com/Keyfactor/keyfactor-go-client/v2 v2.1.2
 	github.com/hashicorp/terraform-plugin-framework v0.10.0
 	github.com/hashicorp/terraform-plugin-go v0.18.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Keyfactor/keyfactor-go-client v1.4.3 h1:CmGvWcuIbDRFM0PfYOQH6UdtAgplvZBpU++KTU8iseg=
 github.com/Keyfactor/keyfactor-go-client-sdk v1.0.1 h1:cs8hhvsY3MJ2o1K11HLTRCjRT8SbsKhhi73Y4By2CI0=
-github.com/Keyfactor/keyfactor-go-client/v2 v2.1.1 h1:JsPl0UGSc1mIbNo86PF5SSLCegf8ro/7voNwBYmsQvQ=
-github.com/Keyfactor/keyfactor-go-client/v2 v2.1.1/go.mod h1:3mfxdcwntB532QIATokBEkBCH0eXN2G/cdMZtu9NwNg=
+github.com/Keyfactor/keyfactor-go-client/v2 v2.1.2 h1:7ByhY5OPu/aE7JTrDb9kR0fQez1qTvFBAS2S0Gq8NCI=
+github.com/Keyfactor/keyfactor-go-client/v2 v2.1.2/go.mod h1:3mfxdcwntB532QIATokBEkBCH0eXN2G/cdMZtu9NwNg=
 github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 h1:wPbRQzjjwFc0ih8puEVAOFGELsn1zoIIYdxvML7mDxA=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8/go.mod h1:I0gYDMZ6Z5GRU7l58bNFSkPTFN6Yl12dsUlAZ8xy98g=

--- a/keyfactor/helpers.go
+++ b/keyfactor/helpers.go
@@ -520,6 +520,12 @@ func sortInSameOrder(unsortedList, sortedList []string) []string {
 	// This is needed because the API returns the list in a different order than the order we sent it in
 	// This is needed for the terraform import command to work
 	var sorted []string
+
+	//if lists are not the same length don't waste the effort and return unsortedList
+	if len(unsortedList) != len(sortedList) {
+		return unsortedList
+	}
+
 	for _, v := range sortedList {
 		for _, u := range unsortedList {
 			if v == u {

--- a/keyfactor/models.go
+++ b/keyfactor/models.go
@@ -60,12 +60,11 @@ type KeyfactorCertificate struct {
 	IssuerDN     types.String `tfsdk:"issuer_dn"`
 	Thumbprint   types.String `tfsdk:"thumbprint"`
 	// Certificate Data Fields
-	PEM          types.String `tfsdk:"certificate_pem"`
-	PEMCACert    types.String `tfsdk:"ca_certificate"`
-	PEMChain     types.String `tfsdk:"certificate_chain"`
-	PrivateKey   types.String `tfsdk:"private_key"`
-	KeyPassword  types.String `tfsdk:"key_password"`
-	AutoPassword types.String `tfsdk:"auto_password"`
+	PEM         types.String `tfsdk:"certificate_pem"`
+	PEMCACert   types.String `tfsdk:"ca_certificate"`
+	PEMChain    types.String `tfsdk:"certificate_chain"`
+	PrivateKey  types.String `tfsdk:"private_key"`
+	KeyPassword types.String `tfsdk:"key_password"`
 	// Keyfactor Fields
 	CertificateAuthority types.String `tfsdk:"certificate_authority"`
 	CertificateTemplate  types.String `tfsdk:"certificate_template"`


### PR DESCRIPTION
…ll not store auto password used to recover private key. `auto_password` has been removed from schema and state.

fix(certificates): `keyfactor_certificate` resource type will no longer trigger replacement if `key_password` is changed. #74 #79 #80
fix(certificates): When looking up a certificate by CN, `IncludeHasPrivateKey` is now included in the call to the Command API.
fix(certificates): When sorting SAN lists, if length varies don't even try to sort as there is obviously a change and replacement must be triggered.