### PR TITLE
fix(cert-store): preserve existing container assignment when config declares no name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v2.9.1
+
+## Certificate Stores
+
+### Fixes
+
+- fix: `keyfactor_certificate_store` `Update` no longer silently clears an existing container/application assignment when `application_name`/`container_name` is not declared in config — a resolved container ID of `0` was previously omitted from the update request entirely, which Command interprets as "unassign," destroying a real out-of-band assignment before Terraform's own consistency check could even flag it. The existing `container_id` is now preserved whenever prior state shows a real assignment and the plan gives no explicit name. Fixes [#175](https://github.com/keyfactor-pub/terraform-provider-keyfactor/issues/175)
+- fix: `keyfactor_certificate_store` container/application name resolution (`lookupContainerNameByID`) now retries via the list endpoint before falling back to a hint, reducing spurious `container_name`/`application_name` nulling on a single transient/permission-scoped lookup failure
+
 # v2.9.0
 
 ## Certificates

--- a/keyfactor/helpers.go
+++ b/keyfactor/helpers.go
@@ -2026,21 +2026,58 @@ func normalizeThumbprint(tp string) string {
 // lookupContainerNameByID resolves a certificate store container/application
 // name from its numeric ID. Uses the by-ID endpoint (single record fetch) so
 // it works for newly-created containers that haven't appeared on the first
-// page of the paginated list endpoint yet. If the by-ID lookup fails, falls
-// back to the supplied hint (e.g. the name from the plan/state). Returns ""
-// when containerId is 0.
+// page of the paginated list endpoint yet. Returns "" when containerId is 0.
+//
+// The Keyfactor Command API and the SDK wrapping it do not expose a
+// structured "not found" sentinel distinct from other errors (a 404 is
+// collapsed into a plain error string alongside network/permission/5xx
+// failures — see keyfactor-go-client's client.go response handling), so this
+// function cannot definitively tell "the container was deleted" apart from
+// "the lookup failed for an unrelated, possibly transient reason." Given that
+// ambiguity, an erroring by-ID lookup is NOT treated as proof the container is
+// gone: it is retried once against the paginated list endpoint (a second,
+// independent code path) before giving up. Only if both lookups fail does the
+// function fall back to hint (e.g. the previously-resolved name from state).
+//
+// This matters because callers write the returned value into
+// container_name/application_name state via syncApplicationAndContainerName.
+// A single transient failure with an empty hint (the case on the very first
+// Read() after an out-of-band container assignment, when state never held a
+// name to fall back to — see GH issue #175) would otherwise permanently null
+// out the name fields even though container_id correctly reflects a real
+// assignment. Note that nulling the *name* fields here is a cosmetic
+// annoyance, not data loss on its own — Update()'s containerId resolution
+// (resolveContainerAssignmentForUpdate) is the load-bearing safeguard against
+// actually clearing the assignment server-side; this function only reduces
+// how often the cosmetic drift happens.
 func lookupContainerNameByID(ctx context.Context, client *api.Client, containerId int, hint string) string {
 	if containerId == 0 {
 		return ""
 	}
-	if client != nil {
-		container, err := client.GetStoreContainer(containerId)
-		if err == nil && container != nil && container.Name != "" {
-			return container.Name
+	if client == nil {
+		return hint
+	}
+
+	container, err := client.GetStoreContainer(containerId)
+	if err == nil && container != nil && container.Name != "" {
+		return container.Name
+	}
+	if err != nil {
+		tflog.Warn(ctx, fmt.Sprintf("Failed to resolve container name for ID %d via by-ID lookup: %s — retrying via the list endpoint before falling back to hint %q", containerId, err.Error(), hint))
+	}
+
+	if containers, listErr := client.GetStoreContainers(); listErr == nil && containers != nil {
+		for _, c := range *containers {
+			if c.Id != nil && *c.Id == containerId && c.Name != "" {
+				return c.Name
+			}
 		}
-		if err != nil {
-			tflog.Warn(ctx, fmt.Sprintf("Failed to resolve container name for ID %d: %s — falling back to hint %q", containerId, err.Error(), hint))
-		}
+	} else if listErr != nil {
+		tflog.Warn(ctx, fmt.Sprintf("Failed to resolve container name for ID %d via list-endpoint fallback: %s — falling back to hint %q", containerId, listErr.Error(), hint))
+	}
+
+	if hint == "" {
+		tflog.Warn(ctx, fmt.Sprintf("Could not resolve a name for container ID %d and no prior state value is available; container_name/application_name will read as null this cycle even though container_id (%d) is real. The underlying container/application assignment itself is not affected by this.", containerId, containerId))
 	}
 	return hint
 }

--- a/keyfactor/resource_keyfactor_certificate_store.go
+++ b/keyfactor/resource_keyfactor_certificate_store.go
@@ -207,8 +207,9 @@ func (r resourceCertificateStore) Create(
 	containerId := 0
 	effectiveName, nameIsNull := plan.effectiveContainerName()
 	if !nameIsNull {
-		storeContainer, containerErr := r.p.client.GetStoreContainer(effectiveName)
-		if containerErr != nil || storeContainer == nil {
+		var containerErr error
+		containerId, containerErr = r.resolveContainerIDByName(effectiveName)
+		if containerErr != nil {
 			response.Diagnostics.AddError(
 				"Invalid application/container name.",
 				fmt.Sprintf(
@@ -219,7 +220,6 @@ func (r resourceCertificateStore) Create(
 			)
 			return
 		}
-		containerId = *storeContainer.Id
 	}
 
 	var properties map[string]string
@@ -339,7 +339,7 @@ func (r resourceCertificateStore) Create(
 		Properties:            propsInterface,
 		AgentId:               agentId,
 		AgentAssigned:         &plan.AgentAssigned.Value,
-		ContainerName:         &effectiveName,
+		ContainerName:         containerNameArgPointer(containerId, effectiveName),
 		InventorySchedule:     schedule,
 		SetNewPasswordAllowed: &plan.SetNewPasswordAllowed.Value,
 		Password:              storePassFormatted,
@@ -463,6 +463,137 @@ func (r resourceCertificateStore) Read(
 	}
 }
 
+// resolveContainerIDByName looks up a container/application by name and
+// returns its numeric ID. Shared by Create() and
+// resolveContainerAssignmentForUpdate so the lookup (and its error handling)
+// doesn't drift between the two call sites. Guards against a latent
+// nil-pointer dereference that existed in both call sites previously: the API
+// can return a nil container alongside a nil error (nothing found, no
+// explicit failure), and calling .Error() on a nil error panics.
+func (r resourceCertificateStore) resolveContainerIDByName(name string) (int, error) {
+	storeContainer, err := r.p.client.GetStoreContainer(name)
+	if err != nil {
+		return 0, err
+	}
+	if storeContainer == nil || storeContainer.Id == nil {
+		return 0, fmt.Errorf("container/application %q not found", name)
+	}
+	return *storeContainer.Id, nil
+}
+
+// containerNameArgPointer builds the ContainerName pointer for
+// Create/UpdateStoreFctArgs from a resolved containerId and name.
+//
+// When containerId is nonzero, an unresolved (empty) name is omitted from the
+// request (via stringToPointer, which maps "" to nil, omitted by the
+// `omitempty` tag) rather than sent as a literal empty string — pairing a
+// real, nonzero containerId with an explicit empty ContainerName is a
+// combination that never occurred before GH issue #175's fix and whose
+// handling on Command's UpdateStore endpoint is unverified; there's no reason
+// to introduce it when omitting the field entirely is both safe and
+// sufficient (containerId is what actually carries the assignment).
+//
+// When containerId is 0, the name is sent explicitly (even if empty) exactly
+// as before this fix — this is the long-standing, tested "no
+// assignment"/explicit-clear request shape and must not change.
+func containerNameArgPointer(containerId int, name string) *string {
+	if containerId != 0 {
+		return stringToPointer(name)
+	}
+	return &name
+}
+
+// resolveContainerAssignmentForUpdate determines the container/application ID
+// (and, best-effort, name) to send in the UpdateStoreFctArgs body during
+// Update().
+//
+// Background (GH issue #175): Command's UpdateStore endpoint treats an
+// omitted ContainerId as an explicit instruction to CLEAR the store's
+// container/application assignment — UpdateStoreFctArgs.ContainerId is
+// `json:"ContainerId,omitempty"`, and intToPointer(0) returns nil, so a
+// resolved containerId of 0 is dropped from the request body entirely rather
+// than sent as an explicit zero. Previously, whenever the plan gave no
+// explicit application_name/container_name (nameIsNull), containerId was
+// simply left at 0 with no regard for whether the store already had a real
+// assignment server-side. That silently deleted a live container/application
+// assignment on the very next Update() — including one that was only ever
+// made out-of-band (e.g. directly via the API) and never represented in
+// Terraform config — well before Terraform's own "inconsistent result after
+// apply" check had a chance to catch anything.
+//
+// effectiveContainerName() (models.go) only checks .Value != "", never
+// .IsNull(), so it collapses two very different signals into the same
+// nameIsNull=true result: "the attribute was never declared in config" and
+// "the attribute was explicitly set to \"\" to clear the assignment." Those
+// must be handled differently — the former should preserve a real existing
+// assignment, but the latter is an explicit user instruction to remove it and
+// must still resolve containerId to 0, exactly as before this fix. This
+// function re-checks plan.ApplicationName/ContainerName directly via
+// IsNull() to tell them apart: it only preserves the existing assignment
+// when BOTH attributes are genuinely null in the plan (truly undeclared). If
+// either was explicitly set (even to ""), that's treated as an explicit
+// clear signal.
+func (r resourceCertificateStore) resolveContainerAssignmentForUpdate(
+	ctx context.Context,
+	plan CertificateStore,
+	state CertificateStore,
+) (containerId int, effectiveName string, err error) {
+	effectiveName, nameIsNull := plan.effectiveContainerName()
+	if !nameIsNull {
+		id, containerErr := r.resolveContainerIDByName(effectiveName)
+		if containerErr != nil {
+			return 0, effectiveName, containerErr
+		}
+		return id, effectiveName, nil
+	}
+
+	planTrulyUndeclared := plan.ApplicationName.IsNull() && plan.ContainerName.IsNull()
+	if planTrulyUndeclared && state.ContainerID.Value != 0 {
+		preservedId := int(state.ContainerID.Value)
+		preservedName, preservedNameIsNull := state.effectiveContainerName()
+		if preservedNameIsNull {
+			// The prior state never resolved a name either (e.g. the
+			// assignment was made out-of-band and this is the first Read()
+			// since). Best-effort re-resolve it directly so the request body
+			// stays internally consistent; an unresolved "" is handled
+			// safely by containerNameArgPointer (omitted, not sent as a
+			// literal empty string) since containerId is what actually
+			// preserves the assignment.
+			preservedName = lookupContainerNameByID(ctx, r.p.client, preservedId, "")
+			if preservedName == "" {
+				tflog.Warn(
+					ctx,
+					fmt.Sprintf(
+						"Update: preserving existing container_id (%d) because config declares no application_name/container_name, but could not resolve its name from state or the API; the request will omit ContainerName (see GH issue #175)",
+						preservedId,
+					),
+				)
+			} else {
+				tflog.Debug(
+					ctx,
+					fmt.Sprintf(
+						"Update: config declares no application_name/container_name; preserving existing container_id (%d), resolved name %q via the API (see GH issue #175)",
+						preservedId,
+						preservedName,
+					),
+				)
+			}
+		} else {
+			tflog.Debug(
+				ctx,
+				fmt.Sprintf(
+					"Update: config declares no application_name/container_name; preserving existing container_id (%d) and name %q from state (see GH issue #175)",
+					preservedId,
+					preservedName,
+				),
+			)
+		}
+		return preservedId, preservedName, nil
+	}
+
+	return 0, "", nil
+}
+
 func (r resourceCertificateStore) Update(
 	ctx context.Context,
 	request tfsdk.UpdateResourceRequest,
@@ -505,22 +636,17 @@ func (r resourceCertificateStore) Update(
 		return
 	}
 
-	containerId := 0
-	updateEffectiveName, updateNameIsNull := plan.effectiveContainerName()
-	if !updateNameIsNull {
-		storeContainer, containerErr := r.p.client.GetStoreContainer(updateEffectiveName)
-		if containerErr != nil || storeContainer == nil {
-			response.Diagnostics.AddError(
-				"Invalid application/container name.",
-				fmt.Sprintf(
-					"Could not retrieve application/container '%s' from Keyfactor: %s",
-					updateEffectiveName,
-					containerErr.Error(),
-				),
-			)
-			return
-		}
-		containerId = *storeContainer.Id
+	containerId, updateEffectiveName, containerErr := r.resolveContainerAssignmentForUpdate(ctx, plan, state)
+	if containerErr != nil {
+		response.Diagnostics.AddError(
+			"Invalid application/container name.",
+			fmt.Sprintf(
+				"Could not retrieve application/container '%s' from Keyfactor: %s",
+				updateEffectiveName,
+				containerErr.Error(),
+			),
+		)
+		return
 	}
 
 	var storePassFormatted *api.UpdateStorePasswordConfig
@@ -653,7 +779,7 @@ func (r resourceCertificateStore) Update(
 		PropertiesString:      propertiesStr,
 		AgentId:               agentId,
 		AgentAssigned:         &agentAssignedVal,
-		ContainerName:         &updateEffectiveName,
+		ContainerName:         containerNameArgPointer(containerId, updateEffectiveName),
 		InventorySchedule:     schedule,
 		SetNewPasswordAllowed: &setNewPasswordAllowedVal,
 		Password:              storePassFormatted,
@@ -708,9 +834,21 @@ func (r resourceCertificateStore) Update(
 		ServerUseSsl:          plan.ServerUseSsl,
 	}
 	// Resolve container name from ContainerId (server never returns ContainerName).
-	// Resolve container name via the by-ID endpoint (list endpoint is paginated).
-	// Fall back to the plan-supplied name when the API lookup is unavailable.
-	result.syncApplicationAndContainerName(lookupContainerNameByID(ctx, r.p.client, updateResponse.ContainerId, updateEffectiveName))
+	//
+	// resolveContainerAssignmentForUpdate already confidently resolved
+	// updateEffectiveName above (either from an explicit plan value, or by
+	// preserving/re-resolving it from state) whenever it's non-empty. As long
+	// as the container/application actually assigned server-side
+	// (updateResponse.ContainerId) matches what we asked for, reuse that name
+	// instead of spending up to 2 more HTTP round trips re-resolving
+	// something we already know. Only fall back to a fresh lookup when we
+	// don't already have a confident answer (updateEffectiveName is empty) or
+	// the server assigned something other than what we requested.
+	if updateResponse.ContainerId == containerId && updateEffectiveName != "" {
+		result.syncApplicationAndContainerName(updateEffectiveName)
+	} else {
+		result.syncApplicationAndContainerName(lookupContainerNameByID(ctx, r.p.client, updateResponse.ContainerId, updateEffectiveName))
+	}
 
 	// Set state
 	diags = response.State.Set(ctx, &result)

--- a/keyfactor/resource_keyfactor_certificate_store_unit_test.go
+++ b/keyfactor/resource_keyfactor_certificate_store_unit_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Keyfactor/keyfactor-auth-client-go/auth_providers"
 	"github.com/Keyfactor/keyfactor-go-client/v3/api"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 // containerLookupMockAuthConfig implements api.AuthConfig for httptest-backed
@@ -117,5 +118,263 @@ func TestUnitLookupContainerNameByID_ZeroIDReturnsEmpty(t *testing.T) {
 	got := lookupContainerNameByID(context.Background(), nil, 0, "anything")
 	if got != "" {
 		t.Fatalf("expected empty result for container ID 0, got %q", got)
+	}
+}
+
+// TestUnitLookupContainerNameByID_ListEndpointFallback is a regression test
+// for GH issue #175's fix #1: an erroring by-ID lookup must not be treated as
+// definitive proof the container is gone. Before this fix, a single failed
+// by-ID lookup fell straight back to hint. This test simulates a by-ID
+// endpoint failure (e.g. a transient/permission-scope error) alongside a
+// working list endpoint that still has the container, and requires the
+// resolver to find the real name via the second, independent path instead of
+// silently discarding it.
+func TestUnitLookupContainerNameByID_ListEndpointFallback(t *testing.T) {
+	const (
+		containerID   = 777
+		containerName = "tf-list-fallback-app"
+	)
+	var byIDHits, listHits int
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/KeyfactorAPI/CertificateStoreContainers/%d", containerID), func(w http.ResponseWriter, r *http.Request) {
+		byIDHits++
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	mux.HandleFunc("/KeyfactorAPI/CertificateStoreContainers/", func(w http.ResponseWriter, r *http.Request) {
+		listHits++
+		id := containerID
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode([]api.CertStoreContainer{{Id: &id, Name: containerName}})
+	})
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	client := newContainerLookupClient(server)
+
+	got := lookupContainerNameByID(context.Background(), client, containerID, "")
+	if got != containerName {
+		t.Fatalf("expected list-endpoint fallback to resolve %q, got %q (byIDHits=%d listHits=%d)", containerName, got, byIDHits, listHits)
+	}
+	if byIDHits == 0 {
+		t.Fatalf("expected the by-ID endpoint to be tried first, got %d hits", byIDHits)
+	}
+}
+
+// TestUnitCertificateStoreUpdate_PreservesContainerAssignmentWhenNameNotDeclared
+// is the red/green regression test for GH issue #175's fix #2 — the
+// load-bearing fix. Root cause: Update() resolved containerId to 0 whenever
+// the plan gave no explicit application_name/container_name, regardless of
+// whether the store already had a real container_id in state. Because
+// UpdateStoreFctArgs.ContainerId is `json:"ContainerId,omitempty"` and
+// intToPointer(0) returns nil, containerId==0 is dropped from the PUT body
+// entirely, and Command interprets the omitted field as "clear the
+// assignment" — deleting a real, live assignment out from under the user.
+//
+// This test constructs a plan/state pair matching that exact scenario
+// (config never declares application_name/container_name; state shows a real
+// nonzero container_id — e.g. from a container assigned out-of-band) and
+// calls resolveContainerAssignmentForUpdate directly. No network is
+// required: the "preserve" branch this test exercises never calls the API
+// client when state already has a resolved name.
+func TestUnitCertificateStoreUpdate_PreservesContainerAssignmentWhenNameNotDeclared(t *testing.T) {
+	r := resourceCertificateStore{p: provider{}}
+
+	state := CertificateStore{
+		ContainerID:     types.Int64{Value: 500},
+		ContainerName:   types.String{Value: "existing-app", Null: false},
+		ApplicationName: types.String{Value: "existing-app", Null: false},
+	}
+	plan := CertificateStore{
+		ContainerName:   types.String{Null: true},
+		ApplicationName: types.String{Null: true},
+	}
+
+	containerId, effectiveName, err := r.resolveContainerAssignmentForUpdate(context.Background(), plan, state)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if containerId != 500 {
+		t.Fatalf(
+			"expected containerId to be preserved from state (500) when plan declares no application_name/container_name, got %d — "+
+				"this reproduces GH issue #175: Update() would omit ContainerId from the PUT body, and Command would clear the assignment",
+			containerId,
+		)
+	}
+	if effectiveName != "existing-app" {
+		t.Fatalf("expected effectiveName to be preserved from state (%q), got %q", "existing-app", effectiveName)
+	}
+}
+
+// TestUnitCertificateStoreUpdate_NoPreservationNeededWhenNeverAssigned covers
+// the companion case: if the store never had a container/application
+// assignment (state.ContainerID == 0) and the plan still declares none, there
+// is nothing to preserve — containerId must resolve to 0 as before, and no
+// warning-worthy "preserving an assignment" behavior should be inferred.
+func TestUnitCertificateStoreUpdate_NoPreservationNeededWhenNeverAssigned(t *testing.T) {
+	r := resourceCertificateStore{p: provider{}}
+
+	state := CertificateStore{
+		ContainerID:     types.Int64{Value: 0},
+		ContainerName:   types.String{Null: true},
+		ApplicationName: types.String{Null: true},
+	}
+	plan := CertificateStore{
+		ContainerName:   types.String{Null: true},
+		ApplicationName: types.String{Null: true},
+	}
+
+	containerId, _, err := r.resolveContainerAssignmentForUpdate(context.Background(), plan, state)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if containerId != 0 {
+		t.Fatalf("expected containerId 0 when the store never had an assignment, got %d", containerId)
+	}
+}
+
+// TestUnitCertificateStoreUpdate_ExplicitEmptyNameClearsAssignment is a
+// regression test for a bug introduced by the fix above and caught in code
+// review: effectiveContainerName() (models.go) only checks .Value != "",
+// never .IsNull(), so it collapses "the attribute was never declared" and
+// "the attribute was explicitly set to \"\"" into the same nameIsNull=true
+// signal. The preservation logic must NOT treat an explicit
+// application_name = "" (or container_name = "") as "never declared" — that
+// is a deliberate user instruction to clear the assignment, and must still
+// resolve containerId to 0 exactly as it did before GH issue #175's fix.
+func TestUnitCertificateStoreUpdate_ExplicitEmptyNameClearsAssignment(t *testing.T) {
+	r := resourceCertificateStore{p: provider{}}
+
+	state := CertificateStore{
+		ContainerID:     types.Int64{Value: 500},
+		ContainerName:   types.String{Value: "existing-app", Null: false},
+		ApplicationName: types.String{Value: "existing-app", Null: false},
+	}
+	// The user explicitly set application_name = "" in config — a known,
+	// non-null (empty) value, NOT an undeclared attribute. container_name is
+	// left undeclared (null); application_name still wins per
+	// effectiveContainerName()'s precedence, but either field being
+	// explicitly non-null must defeat the "truly undeclared" check.
+	plan := CertificateStore{
+		ContainerName:   types.String{Null: true},
+		ApplicationName: types.String{Value: "", Null: false},
+	}
+
+	containerId, effectiveName, err := r.resolveContainerAssignmentForUpdate(context.Background(), plan, state)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if containerId != 0 {
+		t.Fatalf(
+			"expected containerId 0 when application_name is explicitly cleared to \"\", got %d — "+
+				"an explicit clear was incorrectly treated as \"never declared\" and the existing assignment was preserved instead of cleared",
+			containerId,
+		)
+	}
+	if effectiveName != "" {
+		t.Fatalf("expected effectiveName \"\" for an explicit clear, got %q", effectiveName)
+	}
+}
+
+// TestUnitContainerNameArgPointer_NeverPairsNonzeroIdWithEmptyName is a
+// regression test for a second bug caught in code review: when
+// resolveContainerAssignmentForUpdate preserves a real container_id from
+// state but cannot resolve its name (neither state nor a fresh API lookup
+// has it — the exact GH issue #175 scenario on the very first Read() after
+// an out-of-band assignment), the outgoing UpdateStoreFctArgs must never pair
+// a nonzero ContainerId with a literal empty-string ContainerName — an
+// untested combination whose handling by Command's UpdateStore endpoint is
+// unverified. containerNameArgPointer must omit ContainerName (nil, dropped
+// by `omitempty`) in that case, while still preserving the long-standing,
+// tested "explicit clear" shape (containerId 0 + ContainerName "") exactly
+// as before.
+func TestUnitContainerNameArgPointer_NeverPairsNonzeroIdWithEmptyName(t *testing.T) {
+	tests := []struct {
+		name        string
+		containerId int
+		effName     string
+		wantNil     bool
+		wantValue   string
+	}{
+		{
+			name:        "nonzero containerId with unresolved (empty) name omits ContainerName",
+			containerId: 500,
+			effName:     "",
+			wantNil:     true,
+		},
+		{
+			name:        "nonzero containerId with a resolved name sends it explicitly",
+			containerId: 500,
+			effName:     "existing-app",
+			wantNil:     false,
+			wantValue:   "existing-app",
+		},
+		{
+			name:        "zero containerId (explicit clear) still sends an explicit empty ContainerName",
+			containerId: 0,
+			effName:     "",
+			wantNil:     false,
+			wantValue:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := containerNameArgPointer(tt.containerId, tt.effName)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("expected ContainerName to be omitted (nil), got pointer to %q", *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected ContainerName to be sent explicitly as %q, got nil (omitted)", tt.wantValue)
+			}
+			if *got != tt.wantValue {
+				t.Fatalf("expected ContainerName %q, got %q", tt.wantValue, *got)
+			}
+		})
+	}
+}
+
+// TestUnitCertificateStoreUpdate_PreservedAssignmentNeverPairsWithEmptyName
+// combines resolveContainerAssignmentForUpdate and containerNameArgPointer —
+// the same two steps Update() performs — to directly assert the exact
+// outgoing request shape code review flagged: preserving a real container_id
+// whose name cannot be resolved (client is nil here, so both the by-ID and
+// list-endpoint lookups inside lookupContainerNameByID no-op and return "")
+// must never produce ContainerId != 0 paired with ContainerName == "".
+func TestUnitCertificateStoreUpdate_PreservedAssignmentNeverPairsWithEmptyName(t *testing.T) {
+	r := resourceCertificateStore{p: provider{}}
+
+	state := CertificateStore{
+		ContainerID:     types.Int64{Value: 500},
+		ContainerName:   types.String{Null: true},
+		ApplicationName: types.String{Null: true},
+	}
+	plan := CertificateStore{
+		ContainerName:   types.String{Null: true},
+		ApplicationName: types.String{Null: true},
+	}
+
+	containerId, effectiveName, err := r.resolveContainerAssignmentForUpdate(context.Background(), plan, state)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if containerId != 500 {
+		t.Fatalf("expected containerId to be preserved (500), got %d", containerId)
+	}
+	if effectiveName != "" {
+		t.Fatalf("expected effectiveName \"\" (unresolvable with a nil client), got %q", effectiveName)
+	}
+
+	namePtr := containerNameArgPointer(containerId, effectiveName)
+	if containerId != 0 && namePtr != nil {
+		t.Fatalf(
+			"never send a nonzero ContainerId (%d) paired with a literal empty ContainerName — got pointer to %q; "+
+				"ContainerName must be omitted (nil) instead",
+			containerId,
+			*namePtr,
+		)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #175.

`keyfactor_certificate_store` `Update()` resolved `containerId` to `0` whenever `application_name`/`container_name` was absent from config, regardless of whether the store already had a real assignment in state. Since `UpdateStoreFctArgs.ContainerId` is `json:"ContainerId,omitempty"` and `intToPointer(0)` returns `nil`, that `0` was silently dropped from the PUT body, and Command interprets the omission as "unassign" — clearing a real, live container/application assignment server-side (e.g. one made out-of-band via the portal or `PUT /CertificateStores/AssignContainer`) before Terraform's own "inconsistent result after apply" check could even flag anything.

- `containerId` now preserves the existing `state.ContainerID` whenever the plan declares neither `application_name` nor `container_name` at all (both genuinely null). An explicit empty string in either attribute is still treated as an intentional clear and resolves `containerId` to `0`, exactly as before this fix.
- The resolved container name is never sent as a literal empty string alongside a preserved nonzero `containerId` — an untested request shape this fix specifically avoids introducing.
- `lookupContainerNameByID` now retries via the list endpoint before falling back to a hint, reducing spurious `container_name`/`application_name` nulling from a single transient/permission-scoped lookup failure.
- Shared the container-lookup-by-name logic between `Create()` and `Update()` (also fixes a latent nil-pointer dereference that existed in both).
- Removed a redundant duplicate name-lookup API call per `Update()`.

## Test plan

- [x] `make testunit` — 103 pass, 0 fail, 3 pre-existing/unrelated skips
- [x] Red→green regression tests added (network-free, no VCR cassette needed):
  - `TestUnitCertificateStoreUpdate_PreservesContainerAssignmentWhenNameNotDeclared`
  - `TestUnitCertificateStoreUpdate_ExplicitEmptyNameClearsAssignment`
  - `TestUnitContainerNameArgPointer_NeverPairsNonzeroIdWithEmptyName`
  - `TestUnitCertificateStoreUpdate_PreservedAssignmentNeverPairsWithEmptyName`
  - `TestUnitLookupContainerNameByID_ListEndpointFallback`
- [x] `go build ./...` clean, `gofmt` clean
- [x] Vendor-free validation (`rm -rf vendor && go test -mod=mod ./keyfactor/... -run TestUnit`) — identical pass count