### PR TITLE
fix(security-role): detect out-of-band drift on Read

### DIFF
--- a/keyfactor/resource_keyfactor_security_role.go
+++ b/keyfactor/resource_keyfactor_security_role.go
@@ -68,23 +68,41 @@ func (r resourceSecurityRole) Read(
 		return
 	}
 
-	tflog.Info(ctx, "Read called on security remoteState resource")
+	tflog.Info(ctx, "Read called on security role resource")
 	roleId := state.ID.Value
-	//roleName := state.Name.Value
+	roleName := state.Name.Value
 	tflog.SetField(ctx, "role_id", roleId)
 
-	//remoteState, err := r.p.client.GetSecurityRole(int(roleId))
-	//if remoteState == nil {
-	//	response.Diagnostics.AddError("Unknown role error.", fmt.Sprintf("Unable to find role '%s' on Keyfactor. Read failed.", roleName))
-	//	return
-	//}
+	remoteState, err := r.p.client.GetSecurityRole(int(roleId))
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Error reading role from Keyfactor.",
+			fmt.Sprintf("Unknown error while trying to read role '%s' (id %v) on Keyfactor. Read failed. ", roleName, roleId)+err.Error(),
+		)
+		return
+	}
+	if remoteState == nil {
+		response.Diagnostics.AddError(
+			"Unknown role error.",
+			fmt.Sprintf("Unable to find role '%s' (id %v) on Keyfactor. Read failed.", roleName, roleId),
+		)
+		return
+	}
 
-	//if err != nil {
-	//	response.Diagnostics.AddError("Error listing roles from Keyfactor.", "Error reading roles: "+err.Error())
-	//	return
-	//}
+	// permissionsResultForUpdate preserves the plan/state's declared order
+	// when the server's permission set is unchanged, but surfaces the
+	// server's permissions when the set genuinely differs -- this is the
+	// same order-vs-drift invariant Update relies on (see doc comment
+	// above), applied here so Read can detect real out-of-band permission
+	// changes without introducing a spurious alphabetical-resort diff.
+	result := SecurityRole{
+		ID:          types.Int64{Value: int64(remoteState.Id)},
+		Name:        types.String{Value: remoteState.Name},
+		Description: types.String{Value: remoteState.Description},
+		Permissions: permissionsResultForUpdate(ctx, state.Permissions, &remoteState.Permissions),
+	}
 
-	diags = response.State.Set(ctx, &state)
+	diags = response.State.Set(ctx, &result)
 	response.Diagnostics.Append(diags...)
 	if response.Diagnostics.HasError() {
 		return

--- a/keyfactor/resource_keyfactor_security_role_unit_test.go
+++ b/keyfactor/resource_keyfactor_security_role_unit_test.go
@@ -237,3 +237,171 @@ func TestUnitSecurityRoleResource_UpdateSurfacesRealServerDrift(t *testing.T) {
 		"Update() must write the server's actual permissions into state when they genuinely differ from the plan (real drift), not silently echo back the plan's declared permissions",
 	)
 }
+
+// TestUnitSecurityRoleResource_ReadDetectsOutOfBandDrift is a regression test
+// for resourceSecurityRole.Read never actually contacting Keyfactor Command:
+// since the resource was first written (2022-09-01, commit dc082e2), the
+// GetSecurityRole call in Read was commented out and Read simply re-set
+// whatever was already in Terraform state. Consequence: if a role's name,
+// description, or permissions were changed directly in Command (out-of-band),
+// `terraform plan`/refresh never detected the drift.
+//
+// This exercises the real Read() path against a mock Command server that
+// returns a Description (and Permissions) different from prior state, proving
+// Read now surfaces the server's current values instead of echoing back
+// stale state.
+func TestUnitSecurityRoleResource_ReadDetectsOutOfBandDrift(t *testing.T) {
+	ctx := context.Background()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/KeyfactorAPI/Security/Roles/5", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// Server reports a Description and Permissions set that differ from
+		// prior state -- simulating an out-of-band change made directly in
+		// Keyfactor Command.
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"Id":          5,
+			"Name":        "tf-unit-role",
+			"Description": "Changed out-of-band in Command",
+			"Permissions": []string{"Certificates:Read"},
+		})
+	})
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	client := newCertUpdateMockClient(server)
+
+	schema, sDiags := resourceSecurityRoleType{}.GetSchema(ctx)
+	if sDiags.HasError() {
+		t.Fatalf("GetSchema returned diagnostics: %+v", sDiags)
+	}
+
+	// Prior state reflects what Terraform last knew -- stale relative to the
+	// server's current values above.
+	priorState := SecurityRole{
+		ID:          types.Int64{Value: 5},
+		Name:        types.String{Value: "tf-unit-role"},
+		Description: types.String{Value: "Original description"},
+		Permissions: types.List{ElemType: types.StringType, Elems: []attr.Value{
+			types.String{Value: "Certificates:Read"},
+			types.String{Value: "Certificates:EditMetadata"},
+		}},
+	}
+
+	stateObj := tfsdk.State{Schema: schema}
+	if d := stateObj.Set(ctx, &priorState); d.HasError() {
+		t.Fatalf("test setup: state.Set returned diagnostics: %+v", d)
+	}
+
+	r := resourceSecurityRole{p: provider{configured: true, client: client}}
+
+	req := tfsdk.ReadResourceRequest{State: stateObj}
+	resp := &tfsdk.ReadResourceResponse{State: tfsdk.State{Schema: schema}}
+
+	r.Read(ctx, req, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Read returned unexpected diagnostics: %+v", resp.Diagnostics)
+	}
+
+	var result SecurityRole
+	if d := resp.State.Get(ctx, &result); d.HasError() {
+		t.Fatalf("reading back result state: %+v", d)
+	}
+
+	assert.Equal(
+		t, "Changed out-of-band in Command", result.Description.Value,
+		"Read() must surface the server's current description, not silently re-set stale prior state -- this is the out-of-band drift detection bug",
+	)
+
+	var permissions []string
+	for _, e := range result.Permissions.Elems {
+		s, ok := e.(types.String)
+		if !ok {
+			t.Fatalf("expected permissions element to be types.String, got %T", e)
+		}
+		permissions = append(permissions, s.Value)
+	}
+	assert.Equal(
+		t, []string{"Certificates:Read"}, permissions,
+		"Read() must surface the server's actual permission set when it genuinely differs from prior state (real drift), not echo back stale state",
+	)
+}
+
+// TestUnitSecurityRoleResource_ReadPreservesPermissionsOrderWhenUnchanged is
+// the companion test to
+// TestUnitSecurityRoleResource_ReadDetectsOutOfBandDrift: it guards against a
+// naive fix that always writes the server's (alphabetically sorted)
+// permissions into state on Read, which would introduce a spurious
+// "permissions reordered" diff on every refresh even when nothing changed.
+// When the server's permission set is unchanged (same set, any order), Read
+// must preserve the state's declared order.
+func TestUnitSecurityRoleResource_ReadPreservesPermissionsOrderWhenUnchanged(t *testing.T) {
+	ctx := context.Background()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/KeyfactorAPI/Security/Roles/5", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// Server returns the same set of permissions as prior state, but
+		// alphabetically sorted -- a different order.
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"Id":          5,
+			"Name":        "tf-unit-role",
+			"Description": "Unit test role",
+			"Permissions": []string{"Certificates:EditMetadata", "Certificates:Read"},
+		})
+	})
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	client := newCertUpdateMockClient(server)
+
+	schema, sDiags := resourceSecurityRoleType{}.GetSchema(ctx)
+	if sDiags.HasError() {
+		t.Fatalf("GetSchema returned diagnostics: %+v", sDiags)
+	}
+
+	// Prior state declares permissions in non-alphabetical order.
+	priorState := SecurityRole{
+		ID:          types.Int64{Value: 5},
+		Name:        types.String{Value: "tf-unit-role"},
+		Description: types.String{Value: "Unit test role"},
+		Permissions: types.List{ElemType: types.StringType, Elems: []attr.Value{
+			types.String{Value: "Certificates:Read"},
+			types.String{Value: "Certificates:EditMetadata"},
+		}},
+	}
+
+	stateObj := tfsdk.State{Schema: schema}
+	if d := stateObj.Set(ctx, &priorState); d.HasError() {
+		t.Fatalf("test setup: state.Set returned diagnostics: %+v", d)
+	}
+
+	r := resourceSecurityRole{p: provider{configured: true, client: client}}
+
+	req := tfsdk.ReadResourceRequest{State: stateObj}
+	resp := &tfsdk.ReadResourceResponse{State: tfsdk.State{Schema: schema}}
+
+	r.Read(ctx, req, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Read returned unexpected diagnostics: %+v", resp.Diagnostics)
+	}
+
+	var result SecurityRole
+	if d := resp.State.Get(ctx, &result); d.HasError() {
+		t.Fatalf("reading back result state: %+v", d)
+	}
+
+	var permissions []string
+	for _, e := range result.Permissions.Elems {
+		s, ok := e.(types.String)
+		if !ok {
+			t.Fatalf("expected permissions element to be types.String, got %T", e)
+		}
+		permissions = append(permissions, s.Value)
+	}
+
+	assert.Equal(
+		t, []string{"Certificates:Read", "Certificates:EditMetadata"}, permissions,
+		"Read() must preserve prior state's declared permissions order when the server's set is unchanged, not write back a re-sorted server copy",
+	)
+}

--- a/keyfactor/testdata/cassettes/security_role_resource.params.json
+++ b/keyfactor/testdata/cassettes/security_role_resource.params.json
@@ -1,1 +1,1 @@
-{"role_name":"tf-unit-role-457919000"}
+{"role_name":"tf-unit-role-576809000"}

--- a/keyfactor/testdata/cassettes/security_role_resource.yaml
+++ b/keyfactor/testdata/cassettes/security_role_resource.yaml
@@ -8,7 +8,7 @@ interactions:
         proto_minor: 1
         content_length: 81
         host: int25-4-1.kftestlab.com
-        body: '{"Name":"tf-unit-role-457919000","Description":"Unit test role","Permissions":[]}'
+        body: '{"Name":"tf-unit-role-576809000","Description":"Unit test role","Permissions":[]}'
         headers:
             Accept:
                 - application/json
@@ -25,7 +25,7 @@ interactions:
         proto_major: 1
         proto_minor: 1
         content_length: 245
-        body: '{"Id":109,"Description":"Unit test role","EmailAddress":null,"Enabled":true,"Immutable":false,"Valid":true,"Private":false,"PermissionSetId":"099c05f0-deba-4562-a5b1-f491e19c0749","Identities":[],"Name":"tf-unit-role-457919000","Permissions":[]}'
+        body: '{"Id":909,"Description":"Unit test role","EmailAddress":null,"Enabled":true,"Immutable":false,"Valid":true,"Private":false,"PermissionSetId":"099c05f0-deba-4562-a5b1-f491e19c0749","Identities":[],"Name":"tf-unit-role-576809000","Permissions":[]}'
         headers:
             Api-Supported-Versions:
                 - 1.0, 2
@@ -34,26 +34,26 @@ interactions:
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 19 Mar 2026 23:15:14 GMT
+                - Thu, 16 Jul 2026 17:28:25 GMT
             Server:
                 - istio-envoy
             X-Envoy-Upstream-Service-Time:
-                - "147"
+                - "85"
             X-Keyfactor-Correlation-Id:
-                - ca28d198-539e-456a-9963-917cd4c5cd45
+                - 7c5b48c8-cda3-4c1e-904a-6f89307fe254
             X-Keyfactor-Product-Version:
                 - 25.4.1+dc0db2c8af1baf68b4c0043ec0f0f41a77aee11e
         status: 200 OK
         code: 200
-        duration: 986.251832ms
+        duration: 1.147348337s
     - id: 1
       request:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 145
+        content_length: 4
         host: int25-4-1.kftestlab.com
-        body: '{"Id":109,"Name":"tf-unit-role-457919000","Description":"Unit test role updated","Permissions":["Certificates:EditMetadata","Certificates:Read"]}'
+        body: "null"
         headers:
             Accept:
                 - application/json
@@ -63,34 +63,34 @@ interactions:
                 - "1"
             X-Keyfactor-Requested-With:
                 - APIClient
-        url: https://int25-4-1.kftestlab.com/Keyfactor/API/Security/Roles
-        method: PUT
+        url: https://int25-4-1.kftestlab.com/Keyfactor/API/Security/Roles/909
+        method: GET
       response:
         proto: HTTP/1.1
         proto_major: 1
         proto_minor: 1
-        content_length: 300
-        body: '{"Id":109,"Description":"Unit test role updated","EmailAddress":null,"Enabled":true,"Immutable":false,"Valid":true,"Private":false,"PermissionSetId":"099c05f0-deba-4562-a5b1-f491e19c0749","Identities":[],"Name":"tf-unit-role-457919000","Permissions":["Certificates:EditMetadata","Certificates:Read"]}'
+        content_length: 245
+        body: '{"Id":909,"Description":"Unit test role","EmailAddress":null,"Enabled":true,"Immutable":false,"Valid":true,"Private":false,"PermissionSetId":"099c05f0-deba-4562-a5b1-f491e19c0749","Identities":[],"Name":"tf-unit-role-576809000","Permissions":[]}'
         headers:
             Api-Supported-Versions:
                 - 1.0, 2
             Content-Length:
-                - "300"
+                - "245"
             Content-Type:
                 - application/json; charset=utf-8
             Date:
-                - Thu, 19 Mar 2026 23:15:17 GMT
+                - Thu, 16 Jul 2026 17:28:27 GMT
             Server:
                 - istio-envoy
             X-Envoy-Upstream-Service-Time:
-                - "176"
+                - "32"
             X-Keyfactor-Correlation-Id:
-                - a9489795-f393-403e-ba08-8b9db45093ba
+                - 7478c521-7700-4f00-bcf7-e13214c676a9
             X-Keyfactor-Product-Version:
                 - 25.4.1+dc0db2c8af1baf68b4c0043ec0f0f41a77aee11e
         status: 200 OK
         code: 200
-        duration: 300.101154ms
+        duration: 137.327851ms
     - id: 2
       request:
         proto: HTTP/1.1
@@ -108,7 +108,142 @@ interactions:
                 - "1"
             X-Keyfactor-Requested-With:
                 - APIClient
-        url: https://int25-4-1.kftestlab.com/Keyfactor/API/Security/Roles/109
+        url: https://int25-4-1.kftestlab.com/Keyfactor/API/Security/Roles/909
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 245
+        body: '{"Id":909,"Description":"Unit test role","EmailAddress":null,"Enabled":true,"Immutable":false,"Valid":true,"Private":false,"PermissionSetId":"099c05f0-deba-4562-a5b1-f491e19c0749","Identities":[],"Name":"tf-unit-role-576809000","Permissions":[]}'
+        headers:
+            Api-Supported-Versions:
+                - 1.0, 2
+            Content-Length:
+                - "245"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Thu, 16 Jul 2026 17:28:28 GMT
+            Server:
+                - istio-envoy
+            X-Envoy-Upstream-Service-Time:
+                - "28"
+            X-Keyfactor-Correlation-Id:
+                - 651c8f9e-1473-4e20-b357-8dc59dd79cee
+            X-Keyfactor-Product-Version:
+                - 25.4.1+dc0db2c8af1baf68b4c0043ec0f0f41a77aee11e
+        status: 200 OK
+        code: 200
+        duration: 141.592854ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 145
+        host: int25-4-1.kftestlab.com
+        body: '{"Id":909,"Name":"tf-unit-role-576809000","Description":"Unit test role updated","Permissions":["Certificates:EditMetadata","Certificates:Read"]}'
+        headers:
+            Accept:
+                - application/json
+            Content-Type:
+                - application/json
+            X-Keyfactor-Api-Version:
+                - "1"
+            X-Keyfactor-Requested-With:
+                - APIClient
+        url: https://int25-4-1.kftestlab.com/Keyfactor/API/Security/Roles
+        method: PUT
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 300
+        body: '{"Id":909,"Description":"Unit test role updated","EmailAddress":null,"Enabled":true,"Immutable":false,"Valid":true,"Private":false,"PermissionSetId":"099c05f0-deba-4562-a5b1-f491e19c0749","Identities":[],"Name":"tf-unit-role-576809000","Permissions":["Certificates:EditMetadata","Certificates:Read"]}'
+        headers:
+            Api-Supported-Versions:
+                - 1.0, 2
+            Content-Length:
+                - "300"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Thu, 16 Jul 2026 17:28:28 GMT
+            Server:
+                - istio-envoy
+            X-Envoy-Upstream-Service-Time:
+                - "99"
+            X-Keyfactor-Correlation-Id:
+                - 64aaaa2b-27fc-486f-ae5a-6b149ee177b4
+            X-Keyfactor-Product-Version:
+                - 25.4.1+dc0db2c8af1baf68b4c0043ec0f0f41a77aee11e
+        status: 200 OK
+        code: 200
+        duration: 209.534972ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 4
+        host: int25-4-1.kftestlab.com
+        body: "null"
+        headers:
+            Accept:
+                - application/json
+            Content-Type:
+                - application/json
+            X-Keyfactor-Api-Version:
+                - "1"
+            X-Keyfactor-Requested-With:
+                - APIClient
+        url: https://int25-4-1.kftestlab.com/Keyfactor/API/Security/Roles/909
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 300
+        body: '{"Id":909,"Description":"Unit test role updated","EmailAddress":null,"Enabled":true,"Immutable":false,"Valid":true,"Private":false,"PermissionSetId":"099c05f0-deba-4562-a5b1-f491e19c0749","Identities":[],"Name":"tf-unit-role-576809000","Permissions":["Certificates:EditMetadata","Certificates:Read"]}'
+        headers:
+            Api-Supported-Versions:
+                - 1.0, 2
+            Content-Length:
+                - "300"
+            Content-Type:
+                - application/json; charset=utf-8
+            Date:
+                - Thu, 16 Jul 2026 17:28:29 GMT
+            Server:
+                - istio-envoy
+            X-Envoy-Upstream-Service-Time:
+                - "31"
+            X-Keyfactor-Correlation-Id:
+                - 67abc1e1-fabe-41b8-80e9-4273659dc036
+            X-Keyfactor-Product-Version:
+                - 25.4.1+dc0db2c8af1baf68b4c0043ec0f0f41a77aee11e
+        status: 200 OK
+        code: 200
+        duration: 136.503091ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 4
+        host: int25-4-1.kftestlab.com
+        body: "null"
+        headers:
+            Accept:
+                - application/json
+            Content-Type:
+                - application/json
+            X-Keyfactor-Api-Version:
+                - "1"
+            X-Keyfactor-Requested-With:
+                - APIClient
+        url: https://int25-4-1.kftestlab.com/Keyfactor/API/Security/Roles/909
         method: DELETE
       response:
         proto: HTTP/1.1
@@ -120,15 +255,15 @@ interactions:
             Api-Supported-Versions:
                 - 1.0, 2
             Date:
-                - Thu, 19 Mar 2026 23:15:18 GMT
+                - Thu, 16 Jul 2026 17:28:30 GMT
             Server:
                 - istio-envoy
             X-Envoy-Upstream-Service-Time:
-                - "103"
+                - "63"
             X-Keyfactor-Correlation-Id:
-                - 5b15f104-1cd6-4165-9ffc-35b4e0183fbb
+                - 41c41796-7c50-4e6c-be56-76c296b143ac
             X-Keyfactor-Product-Version:
                 - 25.4.1+dc0db2c8af1baf68b4c0043ec0f0f41a77aee11e
         status: 204 No Content
         code: 204
-        duration: 209.407166ms
+        duration: 164.87594ms


### PR DESCRIPTION
## Summary

`resourceSecurityRole.Read` never actually contacted Keyfactor Command — the `GetSecurityRole` call has been commented out since the resource was first written (2022-09-01, `dc082e2`), so `Read` just re-set whatever was already in Terraform state. Name, description, and permission changes made directly in Command (out-of-band) were invisible to `terraform plan`/refresh for this resource.

Found while independently auditing PR #177 for compliance (SOX/SOC2/SOC1) — flagged as an access-control observability gap since PR #177 fixed the identical bug class (Read masking server-side drift) for `keyfactor_security_identity` and `keyfactor_template_role_binding`, but this instance pre-dates and is out of scope for that PR.

## Changes

- `Read` now calls `GetSecurityRole` and rebuilds state from the server response, mirroring the error handling already used in `ImportState` (nil-result and error both become `AddError`).
- Permissions reuse the existing `permissionsResultForUpdate` helper so the plan's declared order is preserved when the server's permission set is unchanged, but the server's permissions win when the set genuinely differs — avoiding both a spurious reordering diff and a false "no drift" result.
- Re-recorded the `security_role_resource` VCR cassette (and its role-name params sidecar), since `Read` now issues a real `GET Security/Roles/{id}` during the test harness's post-apply refresh.

## Test plan

- [x] Red→green regression tests: `TestUnitSecurityRoleResource_ReadDetectsOutOfBandDrift` (confirmed failing against pre-fix code, confirmed passing after the fix) and `TestUnitSecurityRoleResource_ReadPreservesPermissionsOrderWhenUnchanged` (guards against a naive fix re-sorting permissions alphabetically on every refresh)
- [x] `go build ./...` clean
- [x] `make testunit` green, no new failures