### PR TITLE
fix: triage code-review findings from PR #177

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,11 @@ A resource-wide audit for the same bug class as #175 (a resolved zero/empty/nil 
 - fix: `keyfactor_certificate_template` explicit empty lists (`template_regexes`, `template_defaults`, `enrollment_fields`, `metadata_fields`) now actually clear server-side instead of no-op'ing; 4 Command v25+ attributes now correctly carry forward via `UseStateForUnknown`
 - fix: `keyfactor_pam_provider_type` explicit empty `display_name` is preserved instead of falling back to a server default; a nil `data_type` now reads as null instead of a misleading concrete value
 - fix: `keyfactor_pam_provider` an explicit `param_values` clear now reaches the update request instead of silently no-op'ing
-- fix: `keyfactor_security_identity` `Update` preserves existing roles when `roles` is undeclared (previously stripped all real role assignments); `Read` now detects out-of-band role drift instead of echoing stale state
-- fix: `keyfactor_security_role` `Update` no longer sends an explicit `Permissions: null` when `permissions` is undeclared, and no longer masks real server-side permission drift by echoing the client's raw plan value into state instead of Command's confirmed result
-- fix: `keyfactor_template_role_binding` role attach/detach no longer risks resetting unrelated template settings; `Read` now detects out-of-band role detachment instead of reporting stale success
+- fix: `keyfactor_security_identity` `Update` preserves existing roles when `roles` is undeclared (previously stripped all real role assignments); `Read` now detects out-of-band role drift instead of echoing stale state; `roles` is now `Optional`+`Computed` with `UseStateForUnknown`, fixing a remaining `Provider produced inconsistent result after apply` on any unrelated `Update` to an identity that already had roles assigned
+- fix: `keyfactor_security_role` `Update` no longer sends an explicit `Permissions: null` when `permissions` is undeclared, and no longer masks real server-side permission drift by echoing the client's raw plan value into state instead of Command's confirmed result; `permissions` is now `Optional`+`Computed` with `UseStateForUnknown`, fixing the same `Provider produced inconsistent result after apply` class of failure as the `keyfactor_security_identity` `roles` fix above
+- fix: `keyfactor_template_role_binding` role attach/detach no longer risks resetting unrelated template settings; `Read` now detects out-of-band role detachment instead of reporting stale success, and now surfaces a diagnostic (instead of silently returning) if the template list can't be read
 - fix: `keyfactor_certificate` `owner_role_name` no longer causes a spurious `ChangeCertificateOwnerRole` call (and potential drift) when left undeclared in config
+- fix: OAuth security claims missing a `Provider` sub-object in Command's response (a known omission on some Command/identity-provider combinations) now surface a warning instead of silently sending an empty `ProviderAuthenticationScheme` on the next unrelated `keyfactor_oauth_security_role` or `keyfactor_oauth_security_role_claim_association` update, which risked clearing a real provider association
 
 ## Chore / Internal
 
@@ -39,12 +40,16 @@ A resource-wide audit for the same bug class as #175 (a resolved zero/empty/nil 
 - test(template): re-recorded the five `GET /Templates` VCR cassettes for the paginated request (`?PageReturned&ReturnLimit`); added an opt-in `newVCRProviderFactoriesReplayable` variant used only by the read-only certificate-template data-source unit test.
 - test(integration): two lab-constraint-only failures (`TestIntKeyfactorCertificateResource_SANs`, `TestIntKeyfactorCertificateAuthorityResourceUpdate`) are now handled in-test (skip with warning) so unexpected failures still fail.
 - chore(release): add `# v2.9.1` CHANGELOG section; version set to `2.9.1-rc.1`.
+- refactor: deduped four near-identical `*enumType -> types.Int64` pointer converters (`enrollmentTypePtrToTfInt64`, `keyRetentionPtrToTfInt64`, `cleanupTimeUnitsPtrToTfInt64`, `pamParameterDataTypePtrToTfInt64`) into one generic `enumPtrToTfInt64` helper; no behavior change.
+- refactor: replaced the `getStringType(...).Value` idiom (7 call sites in `helpers.go` and `resource_keyfactor_oauth_security_role_claim_association.go`) with a plain `derefOrEmpty` helper; no behavior change.
+- test: extracted the shared `httptest`-backed mock `AuthConfig` helper (`mockAuthConfig` in `test_helpers_test.go`) that replaced three near-identical per-file mocks in the certificate, certificate-deploy, and OAuth security role claim association unit tests.
 
 ## Pending (before GA v2.9.1)
 
 - **GA dependency gate:** `go.mod` is pinned to `keyfactor-go-client/v3 v3.5.6-rc.2`. Move the pin (and the dependency note above) to GA `v3.5.6` once Keyfactor/keyfactor-go-client#55 and #56 are merged and released. This release stays a prerelease until then.
 - **RC-only validation:** the unit suite is validated against `v3.5.6-rc.2` (including a vendor-free run against the real published module) and integration is green on the lab; re-validate against GA `v3.5.6` before release.
-- **Deferred follow-ups (non-blocking):** extract the shared `httptest` mock helper (currently duplicated across unit tests); optional structured-logging (SIEM-friendly fields) enhancements from the compliance audit.
+- **Deferred follow-ups (non-blocking):** optional structured-logging (SIEM-friendly fields) enhancements from the compliance audit.
+- **Known open gap (not yet fixed):** `keyfactor_certificate_authority` has many Optional+Computed pointer fields where server-side omission could still flip a value to zero — same bug class as the `keyfactor_security_identity`/`keyfactor_security_role` fixes above, unaudited.
 
 # v2.9.0
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -135,6 +135,52 @@ security-identity-demo-omit-update:
 	. $(KEYFACTOR_ENV_FILE) && cd $(PROVIDER_DIR)/terraform/security_identity_demo && $(MAKE) build init validate lab-omit-roles-update SUFFIX="$(SUFFIX)" ACCOUNT_NAME="$(ACCOUNT_NAME)"
 
 
+## pam-provider-type-demo: Full lifecycle smoke test in terraform/pam_provider_type_demo/
+##   (build, init, validate, plan, apply, import, reconcile, drift-check, destroy)
+##   Proves the PR179 enumPtrToTfInt64 refactor (pamParameterDataTypePtrToTfInt64)
+##   didn't regress the real create/read/import round-trip. No behavior change intended.
+##   Usage: make pam-provider-type-demo [SUFFIX=_TF]
+pam-provider-type-demo:
+	. $(KEYFACTOR_ENV_FILE) && cd $(PROVIDER_DIR)/terraform/pam_provider_type_demo && $(MAKE) all SUFFIX="$(SUFFIX)"
+
+## pam-provider-type-demo-apply: Build and apply PAM provider type demo (leave running for portal review)
+pam-provider-type-demo-apply:
+	. $(KEYFACTOR_ENV_FILE) && cd $(PROVIDER_DIR)/terraform/pam_provider_type_demo && $(MAKE) build init validate plan apply SUFFIX="$(SUFFIX)"
+
+## pam-provider-type-demo-destroy: Destroy PAM provider type demo resources
+pam-provider-type-demo-destroy:
+	. $(KEYFACTOR_ENV_FILE) && cd $(PROVIDER_DIR)/terraform/pam_provider_type_demo && $(MAKE) destroy SUFFIX="$(SUFFIX)"
+
+
+## template-role-binding-demo: Full lifecycle smoke test in terraform/template_role_binding_demo/
+##   (build, init, validate, plan, apply, import, reconcile, drift-check, destroy)
+##   Proves the PR179 fix to Read()'s swallowed GetTemplates() API error.
+##   NOTE: as of this writing, `apply` fails against int25-4-1.kftestlab.com with
+##   "'Policies' cannot be empty" on every template in that lab — a separate,
+##   pre-existing SDK/Command-API-version gap unrelated to PR179 (see main.tf).
+##   Usage: make template-role-binding-demo [SUFFIX=_TF]
+template-role-binding-demo:
+	. $(KEYFACTOR_ENV_FILE) && cd $(PROVIDER_DIR)/terraform/template_role_binding_demo && $(MAKE) all SUFFIX="$(SUFFIX)"
+
+## template-role-binding-demo-apply: Build and apply template role binding demo (leave running for portal review)
+template-role-binding-demo-apply:
+	. $(KEYFACTOR_ENV_FILE) && cd $(PROVIDER_DIR)/terraform/template_role_binding_demo && $(MAKE) build init validate plan apply SUFFIX="$(SUFFIX)"
+
+## template-role-binding-demo-destroy: Destroy template role binding demo resources
+template-role-binding-demo-destroy:
+	. $(KEYFACTOR_ENV_FILE) && cd $(PROVIDER_DIR)/terraform/template_role_binding_demo && $(MAKE) destroy SUFFIX="$(SUFFIX)"
+
+
+## certificate-authority-demo: Import/read smoke test in terraform/certificate_authority_demo/
+##   Proves the PR179 enumPtrToTfInt64 refactor (enrollmentTypePtrToTfInt64,
+##   keyRetentionPtrToTfInt64, cleanupTimeUnitsPtrToTfInt64) didn't regress
+##   Read()'s enum conversion. Deliberately IMPORT-ONLY -- never creates or
+##   destroys a CA connection; imports the lab's one real CA instead.
+##   Usage: make certificate-authority-demo CA_ID=1
+certificate-authority-demo:
+	. $(KEYFACTOR_ENV_FILE) && cd $(PROVIDER_DIR)/terraform/certificate_authority_demo && $(MAKE) build init validate lab-import-existing lab-drift-check CA_ID="$(CA_ID)"
+
+
 ## k8s-orchestrator-demo: Run full lifecycle demo in terraform/k8s_orchestrator_demo/
 ##   (build, init, validate, plan, apply, import, drift-check, destroy)
 ##   Usage: make k8s-orchestrator-demo
@@ -1323,4 +1369,4 @@ api-get-cert-store:
 		-H "x-keyfactor-api-version: 1" \
 		-H "Authorization: Bearer $$TOKEN" | jq .
 
-.PHONY: store-type-demo application-demo oauth-security-demo oauth-security-demo-apply oauth-security-demo-destroy security-role-permissions-demo security-role-permissions-demo-apply security-role-permissions-demo-destroy security-role-permissions-demo-omit-update security-identity-demo security-identity-demo-apply security-identity-demo-destroy security-identity-demo-omit-update k8s-orchestrator-demo k8s-orchestrator-demo-apply k8s-orchestrator-demo-destroy ecc-pfx-debug-build ecc-pfx-debug-plan ecc-pfx-debug-apply ecc-pfx-debug-destroy build release install test testacc testunit testunit-record testunit-record-one testunit-record-csr testunit-record-cert-import testunit-record-keytypes testunit-record-keytypes-pfx testunit-record-keytypes-csr testunit-record-application testunit-record-pam-provider testunit-record-pam-provider-type testunit-record-security-identity testunit-record-security-role testunit-record-cert-store-type testunit-record-cert-store-types testunit-record-cert-store-ds-guid testunit-record-agent-ds testunit-record-permission-set testunit-record-oauth-claim testunit-record-oauth-role testunit-record-oauth-role-ds testunit-record-oauth-role-claim-assoc testunit-record-enrollment-pattern testunit-record-application-schedules testunit-record-cert-authority testunit-record-cert-template testunit-record-cert-deploy testunit-record-template-role-binding testunit-record-template-role-binding-import testunit-record-cert-store-import testunit-record-oauth-role-import testunit-record-oauth-role-claim-assoc-import testunit-record-oauth-role-claim-assoc-multi testunit-record-oauth-role-nil testunit-record-oauth-claim-nil testunit-record-all testunit-check testunit-ca testint testint-check testint-run testint-debug testint-debug-run testint-pam testint-ca testint-template testint-keytypes-pfx testint-keytypes-csr testint-oauth-access-token testint-ca-snapshot testint-ca-diff testall lint check vet fmtcheck fmt tag setversion vendor vendor-dev showlines api-list-applications api-list-cas api-get-ca api-list-cas-short api-update-ca api-ca-schema-diff api-ca-gap-fields api-get-application api-create-application api-update-application api-delete-application api-options-application api-list-pam-providers api-get-pam-provider api-delete-pam-provider api-list-pam-provider-types api-get-pam-provider-type api-delete-pam-provider-type api-list-templates api-get-template api-list-certs api-get-cert api-download-cert api-inspect-cert-download api-recover-cert api-recover-cert-pfx api-inspect-cert-recover-pfx api-recover-cert-pem api-list-enrollment-patterns api-get-enrollment-pattern api-enroll-pfx-rsa api-enroll-pfx-rsa-2048 api-enroll-pfx-rsa-3072 api-enroll-pfx-rsa-4096 api-enroll-pfx-rsa-8192 api-enroll-pfx-ecc-p256 api-enroll-pfx-ecc-p384 api-enroll-pfx-ecc-p521 api-enroll-pfx-ecc-p256-both api-enroll-pfx-ecc-p384-both api-enroll-pfx-ecc-p521-both api-enroll-pfx-ecc-curve api-enroll-pfx-ecc-keylen api-enroll-pfx-ecc-nokey api-enroll-pfx-ed25519 api-enroll-pfx-ed448 api-enroll-pfx-ed25519-tmpl api-enroll-pfx-ed448-tmpl api-enroll-pfx-ed25519-both api-enroll-pfx-ed448-both api-enroll-pfx-ed25519-altkey api-enroll-pfx-ed448-altkey api-enroll-pfx-ed25519-255 api-enroll-pfx-ed25519-256 api-enroll-pfx-ed448-448 api-enroll-pfx-ed25519-v1 api-enroll-pfx-ed448-v1 api-check-cert-key api-list-agents
+.PHONY: store-type-demo application-demo oauth-security-demo oauth-security-demo-apply oauth-security-demo-destroy security-role-permissions-demo security-role-permissions-demo-apply security-role-permissions-demo-destroy security-role-permissions-demo-omit-update security-identity-demo security-identity-demo-apply security-identity-demo-destroy security-identity-demo-omit-update pam-provider-type-demo pam-provider-type-demo-apply pam-provider-type-demo-destroy template-role-binding-demo template-role-binding-demo-apply template-role-binding-demo-destroy certificate-authority-demo k8s-orchestrator-demo k8s-orchestrator-demo-apply k8s-orchestrator-demo-destroy ecc-pfx-debug-build ecc-pfx-debug-plan ecc-pfx-debug-apply ecc-pfx-debug-destroy build release install test testacc testunit testunit-record testunit-record-one testunit-record-csr testunit-record-cert-import testunit-record-keytypes testunit-record-keytypes-pfx testunit-record-keytypes-csr testunit-record-application testunit-record-pam-provider testunit-record-pam-provider-type testunit-record-security-identity testunit-record-security-role testunit-record-cert-store-type testunit-record-cert-store-types testunit-record-cert-store-ds-guid testunit-record-agent-ds testunit-record-permission-set testunit-record-oauth-claim testunit-record-oauth-role testunit-record-oauth-role-ds testunit-record-oauth-role-claim-assoc testunit-record-enrollment-pattern testunit-record-application-schedules testunit-record-cert-authority testunit-record-cert-template testunit-record-cert-deploy testunit-record-template-role-binding testunit-record-template-role-binding-import testunit-record-cert-store-import testunit-record-oauth-role-import testunit-record-oauth-role-claim-assoc-import testunit-record-oauth-role-claim-assoc-multi testunit-record-oauth-role-nil testunit-record-oauth-claim-nil testunit-record-all testunit-check testunit-ca testint testint-check testint-run testint-debug testint-debug-run testint-pam testint-ca testint-template testint-keytypes-pfx testint-keytypes-csr testint-oauth-access-token testint-ca-snapshot testint-ca-diff testall lint check vet fmtcheck fmt tag setversion vendor vendor-dev showlines api-list-applications api-list-cas api-get-ca api-list-cas-short api-update-ca api-ca-schema-diff api-ca-gap-fields api-get-application api-create-application api-update-application api-delete-application api-options-application api-list-pam-providers api-get-pam-provider api-delete-pam-provider api-list-pam-provider-types api-get-pam-provider-type api-delete-pam-provider-type api-list-templates api-get-template api-list-certs api-get-cert api-download-cert api-inspect-cert-download api-recover-cert api-recover-cert-pfx api-inspect-cert-recover-pfx api-recover-cert-pem api-list-enrollment-patterns api-get-enrollment-pattern api-enroll-pfx-rsa api-enroll-pfx-rsa-2048 api-enroll-pfx-rsa-3072 api-enroll-pfx-rsa-4096 api-enroll-pfx-rsa-8192 api-enroll-pfx-ecc-p256 api-enroll-pfx-ecc-p384 api-enroll-pfx-ecc-p521 api-enroll-pfx-ecc-p256-both api-enroll-pfx-ecc-p384-both api-enroll-pfx-ecc-p521-both api-enroll-pfx-ecc-curve api-enroll-pfx-ecc-keylen api-enroll-pfx-ecc-nokey api-enroll-pfx-ed25519 api-enroll-pfx-ed448 api-enroll-pfx-ed25519-tmpl api-enroll-pfx-ed448-tmpl api-enroll-pfx-ed25519-both api-enroll-pfx-ed448-both api-enroll-pfx-ed25519-altkey api-enroll-pfx-ed448-altkey api-enroll-pfx-ed25519-255 api-enroll-pfx-ed25519-256 api-enroll-pfx-ed448-448 api-enroll-pfx-ed25519-v1 api-enroll-pfx-ed448-v1 api-check-cert-key api-list-agents

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -65,6 +65,76 @@ oauth-security-demo-destroy:
 	. $(KEYFACTOR_ENV_FILE) && cd $(PROVIDER_DIR)/terraform/oauth_security_demo && $(MAKE) destroy SUFFIX="$(SUFFIX)"
 
 
+## security-role-demo: Run full lifecycle demo in terraform/security_role_demo/
+##   (build, init, validate, plan, apply, import, reconcile, drift-check, destroy)
+##   Usage: make security-role-demo [SUFFIX=_TF]
+security-role-demo:
+	. $(KEYFACTOR_ENV_FILE) && cd $(PROVIDER_DIR)/terraform/security_role_demo && $(MAKE) all SUFFIX="$(SUFFIX)"
+
+## security-role-demo-apply: Build and apply security role demo (leave running for portal review)
+security-role-demo-apply:
+	. $(KEYFACTOR_ENV_FILE) && cd $(PROVIDER_DIR)/terraform/security_role_demo && $(MAKE) build init validate plan apply SUFFIX="$(SUFFIX)"
+
+## security-role-demo-destroy: Destroy security role demo resources
+security-role-demo-destroy:
+	. $(KEYFACTOR_ENV_FILE) && cd $(PROVIDER_DIR)/terraform/security_role_demo && $(MAKE) destroy SUFFIX="$(SUFFIX)"
+
+## security-role-demo-oob-drift: Regression proof for PR178 — mutate the role's
+##   permissions out-of-band via a direct Command API call and verify
+##   `terraform plan` detects the drift instead of reporting "No changes".
+security-role-demo-oob-drift:
+	. $(KEYFACTOR_ENV_FILE) && cd $(PROVIDER_DIR)/terraform/security_role_demo && $(MAKE) build init validate lab-oob-drift SUFFIX="$(SUFFIX)"
+
+
+## security-role-permissions-demo: Run full lifecycle demo in terraform/security_role_permissions_demo/
+##   (build, init, validate, plan, apply, import, reconcile, drift-check, destroy)
+##   Separate demo from security-role-demo (PR178); proves the different
+##   PR179 permissions Optional+Computed fix.
+##   Usage: make security-role-permissions-demo [SUFFIX=_TF]
+security-role-permissions-demo:
+	. $(KEYFACTOR_ENV_FILE) && cd $(PROVIDER_DIR)/terraform/security_role_permissions_demo && $(MAKE) all SUFFIX="$(SUFFIX)"
+
+## security-role-permissions-demo-apply: Build and apply security role permissions demo (leave running for portal review)
+security-role-permissions-demo-apply:
+	. $(KEYFACTOR_ENV_FILE) && cd $(PROVIDER_DIR)/terraform/security_role_permissions_demo && $(MAKE) build init validate plan apply SUFFIX="$(SUFFIX)"
+
+## security-role-permissions-demo-destroy: Destroy security role permissions demo resources
+security-role-permissions-demo-destroy:
+	. $(KEYFACTOR_ENV_FILE) && cd $(PROVIDER_DIR)/terraform/security_role_permissions_demo && $(MAKE) destroy SUFFIX="$(SUFFIX)"
+
+## security-role-permissions-demo-omit-update: Regression proof for PR179 — apply with
+##   permissions declared, then apply again with description changed (unrelated
+##   attribute) and permissions omitted from config; must succeed without an
+##   inconsistent-result crash and permissions must remain intact server-side.
+security-role-permissions-demo-omit-update:
+	. $(KEYFACTOR_ENV_FILE) && cd $(PROVIDER_DIR)/terraform/security_role_permissions_demo && $(MAKE) build init validate lab-omit-permissions-update SUFFIX="$(SUFFIX)"
+
+
+## security-identity-demo: Run full lifecycle demo in terraform/security_identity_demo/
+##   (build, init, validate, plan, apply, import, reconcile, drift-check, destroy)
+##   NOTE: keyfactor_identity manages AD identities only; the default lab
+##   (KEYFACTOR_ENV_FILE, OAuth/EJBCA, no AD) rejects any account_name at
+##   Create with HTTP 400. Point ACCOUNT_NAME at a real AD-backed lab account.
+##   Usage: make security-identity-demo [SUFFIX=_TF] [ACCOUNT_NAME='DOMAIN\\user']
+security-identity-demo:
+	. $(KEYFACTOR_ENV_FILE) && cd $(PROVIDER_DIR)/terraform/security_identity_demo && $(MAKE) all SUFFIX="$(SUFFIX)" ACCOUNT_NAME="$(ACCOUNT_NAME)"
+
+## security-identity-demo-apply: Build and apply security identity demo (leave running for portal review)
+security-identity-demo-apply:
+	. $(KEYFACTOR_ENV_FILE) && cd $(PROVIDER_DIR)/terraform/security_identity_demo && $(MAKE) build init validate plan apply SUFFIX="$(SUFFIX)" ACCOUNT_NAME="$(ACCOUNT_NAME)"
+
+## security-identity-demo-destroy: Destroy security identity demo resources
+security-identity-demo-destroy:
+	. $(KEYFACTOR_ENV_FILE) && cd $(PROVIDER_DIR)/terraform/security_identity_demo && $(MAKE) destroy SUFFIX="$(SUFFIX)" ACCOUNT_NAME="$(ACCOUNT_NAME)"
+
+## security-identity-demo-omit-update: Regression proof for PR179 — apply with roles
+##   declared, then apply again with roles omitted from config; must succeed
+##   without an inconsistent-result crash and roles must remain intact
+##   server-side. Requires an AD-backed lab (see NOTE above).
+security-identity-demo-omit-update:
+	. $(KEYFACTOR_ENV_FILE) && cd $(PROVIDER_DIR)/terraform/security_identity_demo && $(MAKE) build init validate lab-omit-roles-update SUFFIX="$(SUFFIX)" ACCOUNT_NAME="$(ACCOUNT_NAME)"
+
+
 ## k8s-orchestrator-demo: Run full lifecycle demo in terraform/k8s_orchestrator_demo/
 ##   (build, init, validate, plan, apply, import, drift-check, destroy)
 ##   Usage: make k8s-orchestrator-demo
@@ -1253,4 +1323,4 @@ api-get-cert-store:
 		-H "x-keyfactor-api-version: 1" \
 		-H "Authorization: Bearer $$TOKEN" | jq .
 
-.PHONY: store-type-demo application-demo oauth-security-demo oauth-security-demo-apply oauth-security-demo-destroy k8s-orchestrator-demo k8s-orchestrator-demo-apply k8s-orchestrator-demo-destroy ecc-pfx-debug-build ecc-pfx-debug-plan ecc-pfx-debug-apply ecc-pfx-debug-destroy build release install test testacc testunit testunit-record testunit-record-one testunit-record-csr testunit-record-cert-import testunit-record-keytypes testunit-record-keytypes-pfx testunit-record-keytypes-csr testunit-record-application testunit-record-pam-provider testunit-record-pam-provider-type testunit-record-security-identity testunit-record-security-role testunit-record-cert-store-type testunit-record-cert-store-types testunit-record-cert-store-ds-guid testunit-record-agent-ds testunit-record-permission-set testunit-record-oauth-claim testunit-record-oauth-role testunit-record-oauth-role-ds testunit-record-oauth-role-claim-assoc testunit-record-enrollment-pattern testunit-record-application-schedules testunit-record-cert-authority testunit-record-cert-template testunit-record-cert-deploy testunit-record-template-role-binding testunit-record-template-role-binding-import testunit-record-cert-store-import testunit-record-oauth-role-import testunit-record-oauth-role-claim-assoc-import testunit-record-oauth-role-claim-assoc-multi testunit-record-oauth-role-nil testunit-record-oauth-claim-nil testunit-record-all testunit-check testunit-ca testint testint-check testint-run testint-debug testint-debug-run testint-pam testint-ca testint-template testint-keytypes-pfx testint-keytypes-csr testint-oauth-access-token testint-ca-snapshot testint-ca-diff testall lint check vet fmtcheck fmt tag setversion vendor vendor-dev showlines api-list-applications api-list-cas api-get-ca api-list-cas-short api-update-ca api-ca-schema-diff api-ca-gap-fields api-get-application api-create-application api-update-application api-delete-application api-options-application api-list-pam-providers api-get-pam-provider api-delete-pam-provider api-list-pam-provider-types api-get-pam-provider-type api-delete-pam-provider-type api-list-templates api-get-template api-list-certs api-get-cert api-download-cert api-inspect-cert-download api-recover-cert api-recover-cert-pfx api-inspect-cert-recover-pfx api-recover-cert-pem api-list-enrollment-patterns api-get-enrollment-pattern api-enroll-pfx-rsa api-enroll-pfx-rsa-2048 api-enroll-pfx-rsa-3072 api-enroll-pfx-rsa-4096 api-enroll-pfx-rsa-8192 api-enroll-pfx-ecc-p256 api-enroll-pfx-ecc-p384 api-enroll-pfx-ecc-p521 api-enroll-pfx-ecc-p256-both api-enroll-pfx-ecc-p384-both api-enroll-pfx-ecc-p521-both api-enroll-pfx-ecc-curve api-enroll-pfx-ecc-keylen api-enroll-pfx-ecc-nokey api-enroll-pfx-ed25519 api-enroll-pfx-ed448 api-enroll-pfx-ed25519-tmpl api-enroll-pfx-ed448-tmpl api-enroll-pfx-ed25519-both api-enroll-pfx-ed448-both api-enroll-pfx-ed25519-altkey api-enroll-pfx-ed448-altkey api-enroll-pfx-ed25519-255 api-enroll-pfx-ed25519-256 api-enroll-pfx-ed448-448 api-enroll-pfx-ed25519-v1 api-enroll-pfx-ed448-v1 api-check-cert-key api-list-agents
+.PHONY: store-type-demo application-demo oauth-security-demo oauth-security-demo-apply oauth-security-demo-destroy security-role-permissions-demo security-role-permissions-demo-apply security-role-permissions-demo-destroy security-role-permissions-demo-omit-update security-identity-demo security-identity-demo-apply security-identity-demo-destroy security-identity-demo-omit-update k8s-orchestrator-demo k8s-orchestrator-demo-apply k8s-orchestrator-demo-destroy ecc-pfx-debug-build ecc-pfx-debug-plan ecc-pfx-debug-apply ecc-pfx-debug-destroy build release install test testacc testunit testunit-record testunit-record-one testunit-record-csr testunit-record-cert-import testunit-record-keytypes testunit-record-keytypes-pfx testunit-record-keytypes-csr testunit-record-application testunit-record-pam-provider testunit-record-pam-provider-type testunit-record-security-identity testunit-record-security-role testunit-record-cert-store-type testunit-record-cert-store-types testunit-record-cert-store-ds-guid testunit-record-agent-ds testunit-record-permission-set testunit-record-oauth-claim testunit-record-oauth-role testunit-record-oauth-role-ds testunit-record-oauth-role-claim-assoc testunit-record-enrollment-pattern testunit-record-application-schedules testunit-record-cert-authority testunit-record-cert-template testunit-record-cert-deploy testunit-record-template-role-binding testunit-record-template-role-binding-import testunit-record-cert-store-import testunit-record-oauth-role-import testunit-record-oauth-role-claim-assoc-import testunit-record-oauth-role-claim-assoc-multi testunit-record-oauth-role-nil testunit-record-oauth-claim-nil testunit-record-all testunit-check testunit-ca testint testint-check testint-run testint-debug testint-debug-run testint-pam testint-ca testint-template testint-keytypes-pfx testint-keytypes-csr testint-oauth-access-token testint-ca-snapshot testint-ca-diff testall lint check vet fmtcheck fmt tag setversion vendor vendor-dev showlines api-list-applications api-list-cas api-get-ca api-list-cas-short api-update-ca api-ca-schema-diff api-ca-gap-fields api-get-application api-create-application api-update-application api-delete-application api-options-application api-list-pam-providers api-get-pam-provider api-delete-pam-provider api-list-pam-provider-types api-get-pam-provider-type api-delete-pam-provider-type api-list-templates api-get-template api-list-certs api-get-cert api-download-cert api-inspect-cert-download api-recover-cert api-recover-cert-pfx api-inspect-cert-recover-pfx api-recover-cert-pem api-list-enrollment-patterns api-get-enrollment-pattern api-enroll-pfx-rsa api-enroll-pfx-rsa-2048 api-enroll-pfx-rsa-3072 api-enroll-pfx-rsa-4096 api-enroll-pfx-rsa-8192 api-enroll-pfx-ecc-p256 api-enroll-pfx-ecc-p384 api-enroll-pfx-ecc-p521 api-enroll-pfx-ecc-p256-both api-enroll-pfx-ecc-p384-both api-enroll-pfx-ecc-p521-both api-enroll-pfx-ecc-curve api-enroll-pfx-ecc-keylen api-enroll-pfx-ecc-nokey api-enroll-pfx-ed25519 api-enroll-pfx-ed448 api-enroll-pfx-ed25519-tmpl api-enroll-pfx-ed448-tmpl api-enroll-pfx-ed25519-both api-enroll-pfx-ed448-both api-enroll-pfx-ed25519-altkey api-enroll-pfx-ed448-altkey api-enroll-pfx-ed25519-255 api-enroll-pfx-ed25519-256 api-enroll-pfx-ed448-448 api-enroll-pfx-ed25519-v1 api-enroll-pfx-ed448-v1 api-check-cert-key api-list-agents

--- a/keyfactor/helpers.go
+++ b/keyfactor/helpers.go
@@ -388,10 +388,52 @@ func mapOAuthSecurityClaimsFromRole(
 
 		// claim.Provider may be nil when the API omits the sub-object (the same
 		// condition mapOAuthSecurityClaim already guards against, e.g. Command
-		// 25.5.1 + Authentik OIDC).
+		// 25.5.1 + Authentik OIDC). Unlike mapOAuthSecurityClaim (used for
+		// Read/state-mapping of a single claim, where a `local` prior value is
+		// available to fall back to), this function has no prior-value
+		// fallback: it maps EVERY claim on the role from the server's own
+		// just-fetched response, for callers that need to preserve claims
+		// they are not modifying (resource_keyfactor_oauth_security_role.go's
+		// Update, and the attach/detach paths in
+		// resource_keyfactor_oauth_security_role_claim_association.go) across
+		// a full-replace PUT. If the omission is a genuine "no provider"
+		// state, substituting "" is correct; if it is the same server-side
+		// omission bug the comment above references, silently substituting ""
+		// here sends `"ProviderAuthenticationScheme": ""` for a claim that
+		// still has a real provider association, and the PUT is a full
+		// replace -- Command would clear that claim's provider on an
+		// otherwise-unrelated update. There is no reliable way to distinguish
+		// the two cases from inside this function, so surface a warning
+		// instead of masking the risk.
 		var providerAuthScheme *string
 		if claim.Provider != nil {
 			providerAuthScheme = claim.Provider.AuthenticationScheme.Get()
+		} else {
+			claimId := int32(-1)
+			if claim.Id != nil {
+				claimId = *claim.Id
+			}
+			claimType := ""
+			if v := claim.ClaimType.Get(); v != nil {
+				claimType = *v
+			}
+			claimValue := ""
+			if v := claim.ClaimValue.Get(); v != nil {
+				claimValue = *v
+			}
+			diagnostics.AddWarning(
+				"OAuth security claim missing provider association",
+				fmt.Sprintf(
+					"Keyfactor Command returned claim ID %d (type %q, value %q) with no Provider sub-object. "+
+						"This provider is preserving unrelated claims verbatim across a full-replace update, but "+
+						"cannot tell whether this claim genuinely has no provider association or whether Command "+
+						"omitted a real one (a known issue on some Command/identity-provider combinations, e.g. "+
+						"Command 25.5.1 + Authentik OIDC). ProviderAuthenticationScheme will be sent as an empty "+
+						"string for this claim; if it previously had a provider association, this update may clear "+
+						"it. Verify this claim's provider association in Keyfactor Command after applying.",
+					claimId, claimType, claimValue,
+				),
+			)
 		}
 
 		claimTypeEnum, err := kfv2.ParseCSSCMSCoreEnumsClaimType(*claim.ClaimType.Get())

--- a/keyfactor/helpers.go
+++ b/keyfactor/helpers.go
@@ -451,7 +451,7 @@ func mapOAuthSecurityClaimsFromRole(
 		temp := kfv2.SecurityRoleClaimDefinitionsRoleClaimDefinitionRequest{
 			ClaimType:                    *claimTypeEnum,
 			ClaimValue:                   *claim.ClaimValue.Get(),
-			ProviderAuthenticationScheme: getStringType(providerAuthScheme).Value,
+			ProviderAuthenticationScheme: derefOrEmpty(providerAuthScheme),
 			Description:                  *claim.Description.Get(),
 		}
 		claims = append(claims, temp)
@@ -1942,6 +1942,19 @@ func getStringType(value *string) types.String {
 		return types.String{Value: "", Null: true}
 	}
 	return types.String{Value: *value}
+}
+
+// derefOrEmpty dereferences a *string, returning "" for a nil pointer. Use
+// this directly wherever code needs a plain Go string from an SDK-nullable
+// field and has no use for the Null flag -- e.g. building an SDK request DTO
+// with a plain (non-nullable) string field. getStringType(v).Value is
+// equivalent but round-trips through a types.String purely to throw the Null
+// flag away, which obscures the intent at the call site.
+func derefOrEmpty(v *string) string {
+	if v == nil {
+		return ""
+	}
+	return *v
 }
 
 // Gets Terraform plan for a given resource type. If there's an error retrieving the state, an error is appended to diagnostics.

--- a/keyfactor/helpers.go
+++ b/keyfactor/helpers.go
@@ -1919,6 +1919,22 @@ func ptr[T any](v T) *T {
 	return &v
 }
 
+// enumPtrToTfInt64 converts a pointer to an int32-backed SDK enum type (e.g.
+// CSSCMSCoreEnumsEnrollmentType, CSSCMSCoreEnumsKeyRetentionPolicy,
+// CSSCMSDataModelEnumsCertificateCleanupTimeUnits,
+// CSSCMSDataModelEnumsPamParameterDataType) to a types.Int64. A nil pointer
+// (the server omitted the field) becomes Null, rather than the enum's zero
+// value -- zero is itself a valid, meaningful enum value for several of these
+// types, so collapsing "absent" to 0 would be indistinguishable from the
+// server actually returning 0, and could send a false "0" back on a
+// subsequent PUT.
+func enumPtrToTfInt64[T ~int32](v *T) types.Int64 {
+	if v == nil {
+		return types.Int64{Null: true}
+	}
+	return types.Int64{Value: int64(*v)}
+}
+
 // Converts a pointer to a string to a types.String object.
 // If the pointer is nil, it returns a types.String with Null set to true.
 func getStringType(value *string) types.String {

--- a/keyfactor/helpers_test.go
+++ b/keyfactor/helpers_test.go
@@ -414,3 +414,55 @@ func TestNormalizePEMLineEndings(t *testing.T) {
 		})
 	}
 }
+
+// TestUnitEnumPtrToTfInt64 covers the generic helper that replaced four
+// near-identical 5-line hand-rolled converters (enrollmentTypePtrToTfInt64
+// and keyRetentionPtrToTfInt64 in resource_keyfactor_certificate_authority.go,
+// cleanupTimeUnitsPtrToTfInt64 in the same file, and
+// pamParameterDataTypePtrToTfInt64 in resource_keyfactor_pam_provider_type.go)
+// -- a pure refactor with no intended behavior change. Nil must map to Null
+// (not the enum's zero value, which is itself meaningful for several of
+// these enums), and a non-nil pointer must carry its value through as an
+// int64.
+func TestUnitEnumPtrToTfInt64(t *testing.T) {
+	type fakeEnum int32
+
+	t.Run("nil pointer maps to Null", func(t *testing.T) {
+		got := enumPtrToTfInt64[fakeEnum](nil)
+		assert.True(t, got.Null, "expected Null=true for a nil enum pointer")
+	})
+
+	t.Run("non-nil pointer carries its value, including the enum zero value", func(t *testing.T) {
+		zero := fakeEnum(0)
+		got := enumPtrToTfInt64(&zero)
+		assert.False(t, got.Null, "expected Null=false for a non-nil pointer, even when the pointee is the enum zero value")
+		assert.Equal(t, int64(0), got.Value)
+
+		five := fakeEnum(5)
+		got = enumPtrToTfInt64(&five)
+		assert.False(t, got.Null)
+		assert.Equal(t, int64(5), got.Value)
+	})
+
+	t.Run("thin wrappers around real SDK enum types still delegate correctly", func(t *testing.T) {
+		// Exercises the actual call sites' types, not just the generic
+		// helper directly -- guards against a future edit accidentally
+		// reintroducing divergent behavior in one of the wrappers.
+		assert.True(t, enrollmentTypePtrToTfInt64(nil).Null)
+		assert.True(t, keyRetentionPtrToTfInt64(nil).Null)
+		assert.True(t, cleanupTimeUnitsPtrToTfInt64(nil).Null)
+		assert.True(t, pamParameterDataTypePtrToTfInt64(nil).Null)
+
+		et := kfv1.CSSCMSCoreEnumsEnrollmentType(2)
+		assert.Equal(t, int64(2), enrollmentTypePtrToTfInt64(&et).Value)
+
+		kr := kfv1.CSSCMSCoreEnumsKeyRetentionPolicy(3)
+		assert.Equal(t, int64(3), keyRetentionPtrToTfInt64(&kr).Value)
+
+		ctu := kfv1.CSSCMSDataModelEnumsCertificateCleanupTimeUnits(1)
+		assert.Equal(t, int64(1), cleanupTimeUnitsPtrToTfInt64(&ctu).Value)
+
+		dt := kfv1.CSSCMSDataModelEnumsPamParameterDataType(4)
+		assert.Equal(t, int64(4), pamParameterDataTypePtrToTfInt64(&dt).Value)
+	})
+}

--- a/keyfactor/helpers_test.go
+++ b/keyfactor/helpers_test.go
@@ -316,6 +316,21 @@ func TestUnitMapOAuthSecurityClaimsFromRole_NilProviderDoesNotPanic(t *testing.T
 	// zero-value "" (matching getStringType's null-safe convention used
 	// elsewhere in this file), never panic.
 	assert.Equal(t, "", mapped.ProviderAuthenticationScheme)
+
+	// Silently substituting "" here is itself a corruption risk on the
+	// full-replace PUT this feeds (see the doc comment on
+	// mapOAuthSecurityClaimsFromRole): if Command omitted Provider due to the
+	// known bug rather than the claim genuinely having none, this update
+	// would clear a real provider association. A warning must surface so the
+	// risk is visible instead of masked.
+	foundWarning := false
+	for _, d := range diagnostics.Warnings() {
+		if d.Summary() == "OAuth security claim missing provider association" {
+			foundWarning = true
+			break
+		}
+	}
+	assert.True(t, foundWarning, "expected a warning diagnostic flagging the missing Provider sub-object, got: %+v", diagnostics)
 }
 
 func TestNormalizeSerialNumber(t *testing.T) {

--- a/keyfactor/helpers_test.go
+++ b/keyfactor/helpers_test.go
@@ -466,3 +466,19 @@ func TestUnitEnumPtrToTfInt64(t *testing.T) {
 		assert.Equal(t, int64(4), pamParameterDataTypePtrToTfInt64(&dt).Value)
 	})
 }
+
+// TestUnitDerefOrEmpty covers the plain-string dereference helper that
+// replaced the getStringType(v).Value idiom (a Terraform-state conversion
+// helper being used purely to discard its Null flag) at 7 call sites across
+// helpers.go and resource_keyfactor_oauth_security_role_claim_association.go.
+// No behavior change: nil still maps to "", and a non-nil pointer's value
+// still passes through unchanged.
+func TestUnitDerefOrEmpty(t *testing.T) {
+	assert.Equal(t, "", derefOrEmpty(nil))
+
+	s := "hello"
+	assert.Equal(t, "hello", derefOrEmpty(&s))
+
+	empty := ""
+	assert.Equal(t, "", derefOrEmpty(&empty))
+}

--- a/keyfactor/resource_keyfactor_certificate_authority.go
+++ b/keyfactor/resource_keyfactor_certificate_authority.go
@@ -637,19 +637,13 @@ func boolPtrToTfBool(v *bool) types.Bool {
 // enrollmentTypePtrToTfInt64 converts a *CSSCMSCoreEnumsEnrollmentType pointer to types.Int64.
 // Nil (server field absent) becomes Null so the value is not sent on PUT.
 func enrollmentTypePtrToTfInt64(v *v1.CSSCMSCoreEnumsEnrollmentType) types.Int64 {
-	if v == nil {
-		return types.Int64{Null: true}
-	}
-	return types.Int64{Value: int64(*v)}
+	return enumPtrToTfInt64(v)
 }
 
 // keyRetentionPtrToTfInt64 converts a *CSSCMSCoreEnumsKeyRetentionPolicy pointer to types.Int64.
 // Nil (server field absent) becomes Null so the value is not sent on PUT.
 func keyRetentionPtrToTfInt64(v *v1.CSSCMSCoreEnumsKeyRetentionPolicy) types.Int64 {
-	if v == nil {
-		return types.Int64{Null: true}
-	}
-	return types.Int64{Value: int64(*v)}
+	return enumPtrToTfInt64(v)
 }
 
 // nullableBoolToTfBool converts a NullableBool from the SDK response to a types.Bool.
@@ -664,10 +658,7 @@ func nullableBoolToTfBool(v v1.NullableBool) types.Bool {
 // cleanupTimeUnitsPtrToTfInt64 converts a *CSSCMSDataModelEnumsCertificateCleanupTimeUnits pointer to types.Int64.
 // Nil (server field absent) becomes Null so the value is not sent on PUT.
 func cleanupTimeUnitsPtrToTfInt64(v *v1.CSSCMSDataModelEnumsCertificateCleanupTimeUnits) types.Int64 {
-	if v == nil {
-		return types.Int64{Null: true}
-	}
-	return types.Int64{Value: int64(*v)}
+	return enumPtrToTfInt64(v)
 }
 
 func stringSliceToTfList(vals []string) types.List {

--- a/keyfactor/resource_keyfactor_certificate_deploy_unit_test.go
+++ b/keyfactor/resource_keyfactor_certificate_deploy_unit_test.go
@@ -7,36 +7,17 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/Keyfactor/keyfactor-auth-client-go/auth_providers"
 	"github.com/Keyfactor/keyfactor-go-client/v3/api"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// certDeployMockAuthConfig implements api.AuthConfig for httptest-backed unit
-// tests of the certificate deployment resource.
-type certDeployMockAuthConfig struct {
-	server *httptest.Server
-}
-
-func (m *certDeployMockAuthConfig) GetServerConfig() *auth_providers.Server {
-	return &auth_providers.Server{
-		Host:          m.server.URL,
-		APIPath:       "KeyfactorAPI",
-		SkipTLSVerify: true,
-	}
-}
-
-func (m *certDeployMockAuthConfig) GetHttpClient() (*http.Client, error) {
-	return m.server.Client(), nil
-}
-
-func (m *certDeployMockAuthConfig) Authenticate() error       { return nil }
-func (m *certDeployMockAuthConfig) GetCommandVersion() string { return "25.1.0.0" }
-
+// newCertDeployMockClient builds an api.Client backed by an httptest server,
+// for unit tests of the certificate deployment resource. See mockAuthConfig
+// in test_helpers_test.go.
 func newCertDeployMockClient(server *httptest.Server) *api.Client {
 	return &api.Client{
-		AuthClient: &certDeployMockAuthConfig{server: server},
+		AuthClient: newCertAPIMockAuthConfig(server),
 	}
 }
 

--- a/keyfactor/resource_keyfactor_certificate_unit_test.go
+++ b/keyfactor/resource_keyfactor_certificate_unit_test.go
@@ -6,36 +6,17 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/Keyfactor/keyfactor-auth-client-go/auth_providers"
 	"github.com/Keyfactor/keyfactor-go-client/v3/api"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// certUpdateMockAuthConfig implements api.AuthConfig for httptest-backed unit
-// tests of the certificate resource Update path.
-type certUpdateMockAuthConfig struct {
-	server *httptest.Server
-}
-
-func (m *certUpdateMockAuthConfig) GetServerConfig() *auth_providers.Server {
-	return &auth_providers.Server{
-		Host:          m.server.URL,
-		APIPath:       "KeyfactorAPI",
-		SkipTLSVerify: true,
-	}
-}
-
-func (m *certUpdateMockAuthConfig) GetHttpClient() (*http.Client, error) {
-	return m.server.Client(), nil
-}
-
-func (m *certUpdateMockAuthConfig) Authenticate() error       { return nil }
-func (m *certUpdateMockAuthConfig) GetCommandVersion() string { return "25.1.0.0" }
-
+// newCertUpdateMockClient builds an api.Client backed by an httptest server,
+// for unit tests of the certificate resource Update path. See mockAuthConfig
+// in test_helpers_test.go.
 func newCertUpdateMockClient(server *httptest.Server) *api.Client {
 	return &api.Client{
-		AuthClient: &certUpdateMockAuthConfig{server: server},
+		AuthClient: newCertAPIMockAuthConfig(server),
 	}
 }
 

--- a/keyfactor/resource_keyfactor_oauth_security_role_claim_association.go
+++ b/keyfactor/resource_keyfactor_oauth_security_role_claim_association.go
@@ -187,10 +187,10 @@ func (r resourceOAuthSecurityRoleClaimAssociation) Delete(
 
 	updateReq := api.NewUpdateSecurityRolesRequest(ctx).SecuritySecurityRolesSecurityRoleUpdateRequest(v2.SecuritySecurityRolesSecurityRoleUpdateRequest{
 		Id:              int32(roleId),
-		Name:            getStringType(remoteState.Name.Get()).Value,
-		Description:     getStringType(remoteState.Description.Get()).Value,
+		Name:            derefOrEmpty(remoteState.Name.Get()),
+		Description:     derefOrEmpty(remoteState.Description.Get()),
 		EmailAddress:    remoteState.EmailAddress,
-		PermissionSetId: getStringType(remoteState.PermissionSetId).Value,
+		PermissionSetId: derefOrEmpty(remoteState.PermissionSetId),
 		Permissions:     remoteState.Permissions,
 		Claims:          claims,
 	})
@@ -313,10 +313,10 @@ func (r resourceOAuthSecurityRoleClaimAssociation) Create(
 
 	updateReq := roleApi.NewUpdateSecurityRolesRequest(ctx).SecuritySecurityRolesSecurityRoleUpdateRequest(v2.SecuritySecurityRolesSecurityRoleUpdateRequest{
 		Id:              int32(roleId),
-		Name:            getStringType(remoteRoleState.Name.Get()).Value,
-		Description:     getStringType(remoteRoleState.Description.Get()).Value,
+		Name:            derefOrEmpty(remoteRoleState.Name.Get()),
+		Description:     derefOrEmpty(remoteRoleState.Description.Get()),
 		EmailAddress:    remoteRoleState.EmailAddress,
-		PermissionSetId: getStringType(remoteRoleState.PermissionSetId).Value,
+		PermissionSetId: derefOrEmpty(remoteRoleState.PermissionSetId),
 		Permissions:     remoteRoleState.Permissions,
 		Claims:          updatedClaims,
 	})

--- a/keyfactor/resource_keyfactor_oauth_security_role_claim_association_unit_test.go
+++ b/keyfactor/resource_keyfactor_oauth_security_role_claim_association_unit_test.go
@@ -15,31 +15,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// oauthRoleClaimAssocMockAuthConfig implements the structurally-equivalent
-// AuthConfig interfaces required by the keyfactor-go-client-sdk v1 and v2 API
-// clients (Authenticate, GetHttpClient, GetServerConfig), backed by an
-// httptest server. Host is the bare "host:port" (no scheme) because the SDK's
-// prepareRequest sets url.Host directly from GetServerConfig().Host and forces
-// url.Scheme = "https" itself.
-type oauthRoleClaimAssocMockAuthConfig struct {
-	server *httptest.Server
-}
-
-func (m *oauthRoleClaimAssocMockAuthConfig) GetServerConfig() *auth_providers.Server {
-	return &auth_providers.Server{
-		Host:          strings.TrimPrefix(m.server.URL, "https://"),
-		SkipTLSVerify: true,
-	}
-}
-
-func (m *oauthRoleClaimAssocMockAuthConfig) GetHttpClient() (*http.Client, error) {
-	return m.server.Client(), nil
-}
-
-func (m *oauthRoleClaimAssocMockAuthConfig) Authenticate() error { return nil }
-
+// newOAuthRoleClaimAssocMockClient builds a kfsdk.APIClient backed by an
+// httptest server, for unit tests of the OAuth security role claim
+// association resource. See mockAuthConfig / newSDKMockAuthConfig in
+// test_helpers_test.go.
 func newOAuthRoleClaimAssocMockClient(server *httptest.Server) *kfsdk.APIClient {
-	return kfsdk.NewAPIClientWithAuth(&oauthRoleClaimAssocMockAuthConfig{server: server})
+	return kfsdk.NewAPIClientWithAuth(newSDKMockAuthConfig(server))
 }
 
 // roleResponseBody builds a /Security/Roles/{id} GET response body with Name,

--- a/keyfactor/resource_keyfactor_oauth_security_role_unit_test.go
+++ b/keyfactor/resource_keyfactor_oauth_security_role_unit_test.go
@@ -1,0 +1,195 @@
+package keyfactor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestUnitOAuthSecurityRole_UpdateWarnsOnClaimMissingProvider is a regression
+// test for the corruption risk in mapOAuthSecurityClaimsFromRole
+// (keyfactor/helpers.go): when Command's GET /Security/Roles/{id} response
+// includes a claim with no Provider sub-object, mapOAuthSecurityClaimsFromRole
+// silently substituted an empty string for that claim's
+// ProviderAuthenticationScheme. That value feeds directly into this resource's
+// Update() at the NewUpdateSecurityRolesRequest call below -- an untested,
+// full-replace PUT of the role's ENTIRE claims list. If Command omitted
+// Provider due to a known server-side quirk (see the comment on
+// mapOAuthSecurityClaimsFromRole, e.g. Command 25.5.1 + Authentik OIDC)
+// rather than the claim genuinely having none, an unrelated Update to this
+// role (e.g. changing only email_address) would silently reset that claim's
+// provider association server-side.
+//
+// This drives the real Update() path end-to-end against a mock Command
+// server whose GET /Security/Roles/{id} response includes one claim with
+// Provider present and one with Provider omitted, and asserts:
+//  1. Update() succeeds (does not error) but surfaces a warning diagnostic
+//     naming the affected claim, instead of silently sending the empty
+//     override.
+//  2. The PUT /Security/Roles request body actually sent to Command reflects
+//     what the fix can and cannot do: the well-formed claim's
+//     ProviderAuthenticationScheme round-trips unchanged, while the
+//     Provider-less claim's does go out as "" (the field is a plain
+//     non-nullable string in the SDK request DTO, so there is no way to omit
+//     it) -- proving the warning is necessary because the risk is real, not
+//     eliminated.
+func TestUnitOAuthSecurityRole_UpdateWarnsOnClaimMissingProvider(t *testing.T) {
+	ctx := context.Background()
+
+	const roleId int32 = 42
+
+	var capturedPutBody []byte
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/KeyfactorAPI/Security/Roles/%d", roleId), func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(fmt.Sprintf(`{
+			"Id": %d,
+			"Name": "tf-unit-oauth-role",
+			"Description": "Unit test role",
+			"EmailAddress": "role@example.com",
+			"Immutable": false,
+			"PermissionSetId": "11111111-1111-1111-1111-111111111111",
+			"Permissions": ["Certificates:Read"],
+			"Claims": [
+				{
+					"Id": 1,
+					"Description": "claim with a provider",
+					"ClaimType": "OAuthSubject",
+					"ClaimValue": "well-formed-subject",
+					"Provider": {"Id": "1", "AuthenticationScheme": "System", "DisplayName": "System"}
+				},
+				{
+					"Id": 2,
+					"Description": "claim Command omitted the provider for",
+					"ClaimType": "OAuthSubject",
+					"ClaimValue": "provider-less-subject",
+					"Provider": null
+				}
+			]
+		}`, roleId)))
+	})
+	mux.HandleFunc("/KeyfactorAPI/Security/Roles", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			var err error
+			capturedPutBody, err = io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("failed reading PUT body: %v", err)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(fmt.Sprintf(`{
+			"Id": %d,
+			"Name": "tf-unit-oauth-role",
+			"Description": "Unit test role updated",
+			"EmailAddress": "role@example.com",
+			"Immutable": false,
+			"PermissionSetId": "11111111-1111-1111-1111-111111111111",
+			"Permissions": ["Certificates:Read"],
+			"Claims": []
+		}`, roleId)))
+	})
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	sdkClient := newOAuthRoleClaimAssocMockClient(server)
+
+	schema, sDiags := resourceOAuthSecurityRoleType{}.GetSchema(ctx)
+	if sDiags.HasError() {
+		t.Fatalf("GetSchema returned diagnostics: %+v", sDiags)
+	}
+
+	state := OAuthSecurityRole{
+		ID:              types.Int64{Value: int64(roleId)},
+		Name:            types.String{Value: "tf-unit-oauth-role"},
+		Description:     types.String{Value: "Unit test role"},
+		EmailAddress:    types.String{Value: "role@example.com"},
+		Immutable:       types.Bool{Value: false},
+		PermissionSetId: types.String{Value: "11111111-1111-1111-1111-111111111111"},
+		Permissions: types.Set{ElemType: types.StringType, Elems: []attr.Value{
+			types.String{Value: "Certificates:Read"},
+		}},
+	}
+
+	// An unrelated field changes (description) -- claims are not managed by
+	// this resource's config at all, so the plan is otherwise identical to
+	// state.
+	plan := state
+	plan.Description = types.String{Value: "Unit test role updated"}
+
+	stateObj := tfsdk.State{Schema: schema}
+	if d := stateObj.Set(ctx, &state); d.HasError() {
+		t.Fatalf("test setup: state.Set returned diagnostics: %+v", d)
+	}
+	planObj := tfsdk.Plan{Schema: schema}
+	if d := planObj.Set(ctx, &plan); d.HasError() {
+		t.Fatalf("test setup: plan.Set returned diagnostics: %+v", d)
+	}
+
+	r := resourceOAuthSecurityRole{p: provider{configured: true, sdkClient: sdkClient}}
+
+	req := tfsdk.UpdateResourceRequest{Plan: planObj, State: stateObj}
+	resp := &tfsdk.UpdateResourceResponse{State: tfsdk.State{Schema: schema}}
+
+	r.Update(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Update returned unexpected diagnostic errors: %+v", resp.Diagnostics)
+	}
+
+	foundWarning := false
+	for _, d := range resp.Diagnostics.Warnings() {
+		if d.Summary() == "OAuth security claim missing provider association" {
+			foundWarning = true
+			break
+		}
+	}
+	if !foundWarning {
+		t.Fatalf("expected a warning diagnostic flagging the claim with no Provider sub-object, got: %+v", resp.Diagnostics)
+	}
+
+	// Confirm what was actually sent to Command, so this test fails loudly if
+	// a future change silently starts sending something worse (or if someone
+	// removes the warning while believing the underlying risk was fixed).
+	if len(capturedPutBody) == 0 {
+		t.Fatal("expected the PUT /Security/Roles request body to have been captured")
+	}
+	var putReq struct {
+		Claims []struct {
+			ClaimValue                   string `json:"ClaimValue"`
+			ProviderAuthenticationScheme string `json:"ProviderAuthenticationScheme"`
+		} `json:"Claims"`
+	}
+	if err := json.Unmarshal(capturedPutBody, &putReq); err != nil {
+		t.Fatalf("failed to unmarshal captured PUT body: %v; body: %s", err, string(capturedPutBody))
+	}
+
+	var wellFormedScheme, providerLessScheme string
+	var sawWellFormed, sawProviderLess bool
+	for _, c := range putReq.Claims {
+		switch c.ClaimValue {
+		case "well-formed-subject":
+			wellFormedScheme = c.ProviderAuthenticationScheme
+			sawWellFormed = true
+		case "provider-less-subject":
+			providerLessScheme = c.ProviderAuthenticationScheme
+			sawProviderLess = true
+		}
+	}
+	if !sawWellFormed || !sawProviderLess {
+		t.Fatalf("expected both claims to round-trip into the PUT request, got: %+v", putReq.Claims)
+	}
+	assert.Equal(t, "System", wellFormedScheme, "the claim that DID have a Provider must round-trip its scheme unchanged")
+	assert.Equal(t, "", providerLessScheme, "the claim that Command omitted Provider for is sent with an empty scheme (the SDK request field cannot be omitted) -- this is exactly the risk the warning diagnostic exists to flag")
+}

--- a/keyfactor/resource_keyfactor_pam_provider_type.go
+++ b/keyfactor/resource_keyfactor_pam_provider_type.go
@@ -133,10 +133,7 @@ func pamProviderTypeResponseToState(resp *v1.PAMProviderTypeResponse) KeyfactorP
 // value (0), which is itself a valid, meaningful data type value and must not be
 // conflated with "not set." Nil maps to Null instead of a spurious concrete 0.
 func pamParameterDataTypePtrToTfInt64(v *v1.CSSCMSDataModelEnumsPamParameterDataType) types.Int64 {
-	if v == nil {
-		return types.Int64{Null: true}
-	}
-	return types.Int64{Value: int64(*v)}
+	return enumPtrToTfInt64(v)
 }
 
 func readHTTPResponseBody(resp *http.Response) string {

--- a/keyfactor/resource_keyfactor_security_identity.go
+++ b/keyfactor/resource_keyfactor_security_identity.go
@@ -34,7 +34,11 @@ func (r resourceSecurityIdentityType) GetSchema(_ context.Context) (tfsdk.Schema
 					ElemType: types.StringType,
 				},
 				Optional:    true,
+				Computed:    true,
 				Description: "An array containing the role IDs that the identity is attached to.",
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					tfsdk.UseStateForUnknown(),
+				},
 			},
 			"id": {
 				Type:        types.Int64Type,
@@ -136,13 +140,25 @@ func (r resourceSecurityIdentity) Read(
 	}
 }
 
-// identityRolesDeclared reports whether the plan explicitly declares the roles
-// attribute. roles is Optional (not Computed), so a Null value means the user
-// omitted it from config (preserve existing assignments), while a non-null value
-// — including an explicit empty list — is a full-replace instruction (an empty
-// list clears all roles).
-func identityRolesDeclared(plan SecurityIdentity) bool {
-	return !plan.Roles.Null && !plan.Roles.Unknown
+// identityRolesDeclared reports whether the config explicitly declares the
+// roles attribute. A Null value means the user omitted it from config
+// (preserve existing assignments), while a non-null value — including an
+// explicit empty list — is a full-replace instruction (an empty list clears
+// all roles).
+//
+// This must be evaluated against the CONFIG, not the plan. roles is
+// Optional+Computed (with a UseStateForUnknown plan modifier, added to fix
+// "Provider produced inconsistent result after apply" when an unrelated
+// Update omitted roles from config): when the attribute is genuinely
+// undeclared, Terraform Core still resolves request.Plan.Roles to the prior
+// state's value (copied forward by the plan modifier so the CLI doesn't show
+// spurious "(known after apply)" noise on every unrelated plan). Checking
+// plan.Roles.Null here would therefore always be false, indistinguishable
+// from a real declaration of the same list. request.Config.Roles is never
+// touched by plan modifiers, so it still reports Null exactly when the user
+// omitted the attribute.
+func identityRolesDeclared(config SecurityIdentity) bool {
+	return !config.Roles.Null && !config.Roles.Unknown
 }
 
 func (r resourceSecurityIdentity) Update(
@@ -153,6 +169,16 @@ func (r resourceSecurityIdentity) Update(
 	// Get plan values
 	var plan SecurityIdentity
 	diags := request.Plan.Get(ctx, &plan)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	// Get config values. roles is Optional+Computed, so request.Plan.Roles is
+	// no longer a reliable signal of whether the user declared the attribute
+	// (see identityRolesDeclared's doc comment) — request.Config.Roles is.
+	var config SecurityIdentity
+	diags = request.Config.Get(ctx, &config)
 	response.Diagnostics.Append(diags...)
 	if response.Diagnostics.HasError() {
 		return
@@ -184,7 +210,7 @@ func (r resourceSecurityIdentity) Update(
 		Roles:        state.Roles,
 	}
 
-	if identityRolesDeclared(plan) {
+	if identityRolesDeclared(config) {
 		// Generate API request body from plan
 		var validRolesInterface []interface{}
 		for _, role := range plan.Roles.Elems {
@@ -349,13 +375,25 @@ func (r resourceSecurityIdentity) Create(
 	if validRoles == nil {
 		validRoles = plan.Roles.Elems
 	}
+
+	// roles is Optional+Computed: when config omits it entirely, plan.Roles
+	// arrives Unknown (there's no prior state yet for UseStateForUnknown to
+	// copy forward from during Create). A freshly-created identity genuinely
+	// has no roles unless declared, so resolve Unknown to a concrete empty
+	// list rather than writing an Unknown value into state, which Terraform
+	// Core would reject.
+	resultRoles := plan.Roles
+	if resultRoles.Unknown {
+		resultRoles = types.List{ElemType: types.StringType, Elems: []attr.Value{}}
+	}
+
 	// Generate resource state struct
 	var result = SecurityIdentity{
 		ID:           types.Int64{Value: int64(createResponse.Id)},
 		AccountName:  types.String{Value: accountName},
 		IdentityType: types.String{Value: plan.IdentityType.Value},
 		Valid:        types.Bool{Value: plan.Valid.Value},
-		Roles:        plan.Roles,
+		Roles:        resultRoles,
 	}
 
 	diags = response.State.Set(ctx, result)

--- a/keyfactor/resource_keyfactor_security_identity_test.go
+++ b/keyfactor/resource_keyfactor_security_identity_test.go
@@ -188,13 +188,22 @@ func TestUnitKeyfactorIdentityResource(t *testing.T) {
 		ProtoV6ProviderFactories: factories,
 		Steps: []resource.TestStep{
 			{
-				// Create identity with no roles.
+				// Create identity with no roles declared in config.
 				// identity_type and valid are populated by Read, not Create,
 				// so we only check id and account_name here.
-				// ExpectNonEmptyPlan: the resource has known drift after refresh
-				// (roles [] vs null, computed fields reset) — pre-existing resource bug.
-				Config:             testAccSecurityIdentityResourceConfig(accountName),
-				ExpectNonEmptyPlan: true,
+				//
+				// This step used to carry ExpectNonEmptyPlan: true to tolerate
+				// a known post-refresh drift on `roles` (planned null vs a
+				// concrete [] in state) -- the exact "Provider produced
+				// inconsistent result after apply" bug fixed by making roles
+				// Optional+Computed with a UseStateForUnknown plan modifier
+				// (see identityRolesDeclared's doc comment in
+				// resource_keyfactor_security_identity.go). With that fix,
+				// Terraform Core's post-apply plan is genuinely empty, so
+				// ExpectNonEmptyPlan is removed: if this regresses, this step
+				// starts failing with "Expected an empty plan, but got a
+				// non-empty plan" instead of silently tolerating drift again.
+				Config: testAccSecurityIdentityResourceConfig(accountName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "account_name", stateAccountName),

--- a/keyfactor/resource_keyfactor_security_identity_unit_test.go
+++ b/keyfactor/resource_keyfactor_security_identity_unit_test.go
@@ -153,3 +153,160 @@ func TestUnitSecurityIdentityRead_DetectsOutOfBandRoleDrift(t *testing.T) {
 
 	assert.Equal(t, []string{"RoleB"}, roles, "Read() must reflect the freshly-fetched server roles, not the stale prior-state roles")
 }
+
+// TestUnitSecurityIdentitySchema_RolesIsComputedWithUseStateForUnknown is a
+// regression test for "Provider produced inconsistent result after apply:
+// .roles: was null, but now cty.ListVal(...)".
+//
+// roles was Optional but NOT Computed. Update() (see identityRolesDeclared)
+// deliberately writes state.Roles (a concrete, non-null list) into the result
+// whenever the config omits roles, to preserve the identity's existing role
+// assignments across an unrelated Update. But for a non-Computed attribute,
+// Terraform Core computes the practitioner-facing plan directly from config:
+// omitted config -> planned value is Null, full stop, with no path for a
+// provider-side plan modifier to intervene. When Update() then returned a
+// non-null Roles, Core saw the final value diverge from what it planned and
+// aborted the apply with "inconsistent result after apply" on any identity
+// that already had roles assigned.
+//
+// Why this shipped: this repo's TestUnit* harness (see
+// TestUnitSecurityIdentityRead_DetectsOutOfBandRoleDrift above) calls
+// resourceSecurityIdentity's methods directly via hand-built tfsdk.Plan/
+// tfsdk.State values -- it never drives a real Terraform Core plan/apply
+// cycle (that would require github.com/hashicorp/terraform-plugin-testing,
+// which is not a dependency of this module and is blocked on this repo's
+// terraform-plugin-framework v0.10.0 pin). Because of that, Update()'s
+// returned value looked entirely correct in isolation (it does preserve the
+// right roles) -- the defect is only visible one layer up, in how Terraform
+// Core reconciles the schema-declared plan against that returned value. The
+// strongest regression test achievable without a full Core harness is
+// asserting the schema fix directly, mirroring
+// TestUnitTemplateSchema_V25CleanupFieldsUseStateForUnknown's approach for
+// the same bug class on a different resource: roles must be Optional+Computed
+// with a UseStateForUnknown plan modifier, so Core resolves the omitted-roles
+// case to "carry forward the prior state value" instead of "plan Null."
+func TestUnitSecurityIdentitySchema_RolesIsComputedWithUseStateForUnknown(t *testing.T) {
+	ctx := context.Background()
+
+	schema, diags := resourceSecurityIdentityType{}.GetSchema(ctx)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics building schema: %v", diags)
+	}
+
+	attribute, ok := schema.Attributes["roles"]
+	if !ok {
+		t.Fatalf("expected schema attribute %q to exist", "roles")
+	}
+
+	if !attribute.Optional || !attribute.Computed {
+		t.Fatalf("attribute %q: expected Optional+Computed, got Optional=%v Computed=%v", "roles", attribute.Optional, attribute.Computed)
+	}
+
+	found := false
+	for _, m := range attribute.PlanModifiers {
+		if _, ok := m.(tfsdk.UseStateForUnknownModifier); ok {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("attribute %q: expected UseStateForUnknown plan modifier so an omitted-from-config value carries forward from state instead of planning Null, but none was found (modifiers: %+v)", "roles", attribute.PlanModifiers)
+	}
+}
+
+// TestUnitSecurityIdentityResource_UpdatePreservesRolesWhenConfigOmitsThem is a
+// functional companion to the schema-level test above: it exercises the real
+// Update() path with a Config that omits roles (Null) but a Plan that already
+// carries the prior state's roles forward -- reproducing exactly what
+// UseStateForUnknownModifier hands Update() once the schema fix from
+// TestUnitSecurityIdentitySchema_RolesIsComputedWithUseStateForUnknown is in
+// place (see UseStateForUnknownModifier.Modify in
+// vendor/.../tfsdk/attribute_plan_modification.go: it copies AttributeState
+// into AttributePlan when AttributeConfig is null and AttributePlan is
+// unknown). It asserts Update()'s returned Roles is IDENTICAL to the planned
+// value, which is the actual invariant Terraform Core enforces ("the final
+// value of a Known planned attribute must not change") -- not just "close
+// enough" or "the right role names in some form."
+func TestUnitSecurityIdentityResource_UpdatePreservesRolesWhenConfigOmitsThem(t *testing.T) {
+	ctx := context.Background()
+
+	schema, sDiags := resourceSecurityIdentityType{}.GetSchema(ctx)
+	if sDiags.HasError() {
+		t.Fatalf("GetSchema returned diagnostics: %+v", sDiags)
+	}
+
+	priorRoles := types.List{ElemType: types.StringType, Elems: []attr.Value{
+		types.String{Value: "Administrator"},
+	}}
+
+	state := SecurityIdentity{
+		ID:           types.Int64{Value: 42},
+		AccountName:  types.String{Value: "KEYFACTOR\\\\tf-unit-preserve"},
+		IdentityType: types.String{Value: "User"},
+		Valid:        types.Bool{Value: true},
+		Roles:        priorRoles,
+	}
+
+	// The plan is what UseStateForUnknownModifier produces: the prior state's
+	// roles copied forward because config is null and the raw plan was
+	// unknown. Every other field mirrors an unrelated attribute change (a
+	// realistic "unrelated Update").
+	plan := state
+
+	// The config is what the practitioner actually wrote: roles is genuinely
+	// absent (Null), which is what makes this the undeclared case rather than
+	// an explicit re-declaration of the same list.
+	config := SecurityIdentity{
+		ID:           state.ID,
+		AccountName:  state.AccountName,
+		IdentityType: state.IdentityType,
+		Valid:        state.Valid,
+		Roles:        types.List{Null: true, ElemType: types.StringType},
+	}
+
+	stateObj := tfsdk.State{Schema: schema}
+	if d := stateObj.Set(ctx, &state); d.HasError() {
+		t.Fatalf("test setup: state.Set returned diagnostics: %+v", d)
+	}
+	planObj := tfsdk.Plan{Schema: schema}
+	if d := planObj.Set(ctx, &plan); d.HasError() {
+		t.Fatalf("test setup: plan.Set returned diagnostics: %+v", d)
+	}
+	// tfsdk.Config has no Set method of its own; build its Raw value the same
+	// way Plan/State do and reuse it, since Config/Plan/State all wrap an
+	// identically-shaped (Raw tftypes.Value, Schema tfsdk.Schema) pair.
+	configPlan := tfsdk.Plan{Schema: schema}
+	if d := configPlan.Set(ctx, &config); d.HasError() {
+		t.Fatalf("test setup: config.Set returned diagnostics: %+v", d)
+	}
+	configObj := tfsdk.Config{Schema: schema, Raw: configPlan.Raw}
+
+	r := resourceSecurityIdentity{p: provider{configured: true, client: nil}}
+
+	req := tfsdk.UpdateResourceRequest{Config: configObj, Plan: planObj, State: stateObj}
+	resp := &tfsdk.UpdateResourceResponse{State: tfsdk.State{Schema: schema}}
+
+	r.Update(ctx, req, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Update returned unexpected diagnostics: %+v", resp.Diagnostics)
+	}
+
+	var result SecurityIdentity
+	if d := resp.State.Get(ctx, &result); d.HasError() {
+		t.Fatalf("reading back result state: %+v", d)
+	}
+
+	var gotRoles []string
+	for _, e := range result.Roles.Elems {
+		s, ok := e.(types.String)
+		if !ok {
+			t.Fatalf("expected roles element to be types.String, got %T", e)
+		}
+		gotRoles = append(gotRoles, s.Value)
+	}
+
+	assert.Equal(
+		t, []string{"Administrator"}, gotRoles,
+		"Update() must write exactly the planned roles into state when config omits the attribute -- Terraform Core already committed to this planned value, so any divergence is an inconsistent-result-after-apply error",
+	)
+}

--- a/keyfactor/resource_keyfactor_security_role.go
+++ b/keyfactor/resource_keyfactor_security_role.go
@@ -35,8 +35,12 @@ func (r resourceSecurityRoleType) GetSchema(_ context.Context) (tfsdk.Schema, di
 			"permissions": {
 				Type:                types.ListType{ElemType: types.StringType},
 				Optional:            true,
+				Computed:            true,
 				Description:         "An array containing the permissions assigned to the role in a list of Name:Value pairs",
 				MarkdownDescription: "An array containing the permissions assigned to the role in a list of Name:Value pairs. For more information about allowed permission values, please refer to the Keyfactor Command [Version One Permission Model documentation](https://software.keyfactor.com/Core-OnPrem/Current/Content/ReferenceGuide/SecurityRolePermissions.htm#Version1).",
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					tfsdk.UseStateForUnknown(),
+				},
 			},
 		},
 		Description:         "IMPORTANT:  This has been deprecated since it supports Active Directory identities only. It is retained for backwards compatibility, but all new development should use methods that provide support for alternate identity providers and the newer claims-based authentication model that accompanies this. These newer methods support both Active Directory and other identity providers. See version 2 of this resource.",
@@ -110,15 +114,19 @@ func (r resourceSecurityRole) Read(
 }
 
 // buildSecurityRoleUpdateArg builds the UpdateSecurityRole request from the
-// plan. permissions is Optional (not Computed): a Null value means the user
-// omitted the attribute and the existing permissions must be preserved, so the
-// Permissions field is left nil and omitted from the request (the `omitempty`
-// pointer fires). Previously a Null plan resolved to a nil Go slice that was
-// still wrapped in a non-nil pointer (&permissions); the non-nil pointer
-// bypassed omitempty and marshaled as `"Permissions": null`, telling Command to
-// clear every permission the role had. An explicit empty list is a real clear
-// signal and is sent as `[]`.
-func buildSecurityRoleUpdateArg(ctx context.Context, plan SecurityRole, roleId int) *api.UpdateSecurityRoleArg {
+// plan, given the permissions value to treat as authoritative for "did the
+// user declare this attribute" (see the call site in Update() -- this must be
+// request.Config.Permissions, not request.Plan.Permissions, now that
+// permissions is Optional+Computed; see permissionsResultForUpdate's doc
+// comment for why). A Null value means the user omitted the attribute and the
+// existing permissions must be preserved, so the Permissions field is left
+// nil and omitted from the request (the `omitempty` pointer fires).
+// Previously a Null value resolved to a nil Go slice that was still wrapped
+// in a non-nil pointer (&permissions); the non-nil pointer bypassed omitempty
+// and marshaled as `"Permissions": null`, telling Command to clear every
+// permission the role had. An explicit empty list is a real clear signal and
+// is sent as `[]`.
+func buildSecurityRoleUpdateArg(ctx context.Context, plan SecurityRole, declaredPermissions types.List, roleId int) *api.UpdateSecurityRoleArg {
 	arg := &api.UpdateSecurityRoleArg{
 		Id: roleId,
 		CreateSecurityRoleArg: api.CreateSecurityRoleArg{
@@ -126,9 +134,9 @@ func buildSecurityRoleUpdateArg(ctx context.Context, plan SecurityRole, roleId i
 			Description: plan.Description.Value,
 		},
 	}
-	if !plan.Permissions.Null && !plan.Permissions.Unknown {
+	if !declaredPermissions.Null && !declaredPermissions.Unknown {
 		permissions := []string{}
-		plan.Permissions.ElementsAs(ctx, &permissions, false)
+		declaredPermissions.ElementsAs(ctx, &permissions, false)
 		if permissions == nil {
 			permissions = []string{}
 		}
@@ -169,7 +177,7 @@ func permissionsToTfList(permissions []string) types.List {
 }
 
 // permissionsResultForUpdate decides what to write into state's Permissions
-// after a successful Update: it must preserve plan.Permissions verbatim
+// after a successful Update: it must preserve planPermissions verbatim
 // (declared order intact) when the server's response reports the same set of
 // permissions -- regardless of order -- avoiding the alphabetical-resort
 // drift bug this preserves against. But it must NOT mask genuine server-side
@@ -177,9 +185,22 @@ func permissionsToTfList(permissions []string) types.List {
 // the server's reported set differs from the plan's, the server's
 // permissions are written instead, so real drift surfaces on the next plan.
 //
-// A Null/Unknown plan (permissions undeclared) has nothing to preserve the
-// order of, so it is always treated as "sets differ" and the server's
-// permissions win.
+// A Null/Unknown planPermissions (permissions undeclared) has nothing to
+// preserve the order of, so it is always treated as "sets differ" and the
+// server's permissions win.
+//
+// permissions is Optional+Computed (with a UseStateForUnknown plan modifier,
+// added to fix "Provider produced inconsistent result after apply" when an
+// unrelated Update omitted permissions from config): the Update() call site
+// must pass request.Config.Permissions here, NOT request.Plan.Permissions.
+// Once the modifier is in place, an omitted-from-config Plan value is no
+// longer null -- Terraform Core resolves it to the prior state's value so the
+// CLI doesn't show spurious "(known after apply)" noise on every unrelated
+// plan -- so checking Plan would misclassify "omitted" as "explicitly
+// re-declared the same list", and buildSecurityRoleUpdateArg would start
+// sending an unnecessary Permissions payload on every Update. Config is never
+// touched by plan modifiers, so it still reports Null exactly when the user
+// omitted the attribute.
 func permissionsResultForUpdate(ctx context.Context, planPermissions types.List, remotePermissions *[]string) types.List {
 	var remote []string
 	if remotePermissions != nil {
@@ -213,6 +234,17 @@ func (r resourceSecurityRole) Update(
 		return
 	}
 
+	// Get config values. permissions is Optional+Computed, so
+	// request.Plan.Permissions is no longer a reliable signal of whether the
+	// user declared the attribute (see permissionsResultForUpdate's doc
+	// comment) -- request.Config.Permissions is.
+	var config SecurityRole
+	diags = request.Config.Get(ctx, &config)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
 	tflog.Info(ctx, "Update called on security identity resource")
 
 	// Get current state
@@ -227,7 +259,7 @@ func (r resourceSecurityRole) Update(
 	tflog.SetField(ctx, "id", roleId)
 
 	// Generate API request body from plan
-	updateArg := buildSecurityRoleUpdateArg(ctx, plan, int(roleId))
+	updateArg := buildSecurityRoleUpdateArg(ctx, plan, config.Permissions, int(roleId))
 
 	remoteState, err := r.p.client.UpdateSecurityRole(updateArg)
 	if err != nil {
@@ -242,7 +274,7 @@ func (r resourceSecurityRole) Update(
 		ID:          types.Int64{Value: int64(state.ID.Value)},
 		Name:        types.String{Value: remoteState.Name},
 		Description: types.String{Value: remoteState.Description},
-		Permissions: permissionsResultForUpdate(ctx, plan.Permissions, remoteState.Permissions),
+		Permissions: permissionsResultForUpdate(ctx, config.Permissions, remoteState.Permissions),
 	}
 
 	// Set state
@@ -334,11 +366,22 @@ func (r resourceSecurityRole) Create(
 	}
 	tflog.Trace(ctx, "Created security role", map[string]interface{}{"role_name": plan.Name.Value})
 
+	// permissions is Optional+Computed: when config omits it entirely,
+	// plan.Permissions arrives Unknown (there's no prior state yet for
+	// UseStateForUnknown to copy forward from during Create). A
+	// freshly-created role genuinely has no permissions unless declared, so
+	// resolve Unknown to a concrete empty list rather than writing an Unknown
+	// value into state, which Terraform Core would reject.
+	resultPermissions := plan.Permissions
+	if resultPermissions.Unknown {
+		resultPermissions = types.List{ElemType: types.StringType, Elems: []attr.Value{}}
+	}
+
 	var result = SecurityRole{
 		ID:          types.Int64{Value: int64(createResponse.Id)},
 		Name:        types.String{Value: createResponse.Name},
 		Description: types.String{Value: createResponse.Description},
-		Permissions: plan.Permissions,
+		Permissions: resultPermissions,
 	}
 
 	diags = response.State.Set(ctx, result)

--- a/keyfactor/resource_keyfactor_security_role.go
+++ b/keyfactor/resource_keyfactor_security_role.go
@@ -118,15 +118,24 @@ func (r resourceSecurityRole) Read(
 // user declare this attribute" (see the call site in Update() -- this must be
 // request.Config.Permissions, not request.Plan.Permissions, now that
 // permissions is Optional+Computed; see permissionsResultForUpdate's doc
-// comment for why). A Null value means the user omitted the attribute and the
-// existing permissions must be preserved, so the Permissions field is left
-// nil and omitted from the request (the `omitempty` pointer fires).
-// Previously a Null value resolved to a nil Go slice that was still wrapped
-// in a non-nil pointer (&permissions); the non-nil pointer bypassed omitempty
-// and marshaled as `"Permissions": null`, telling Command to clear every
-// permission the role had. An explicit empty list is a real clear signal and
-// is sent as `[]`.
-func buildSecurityRoleUpdateArg(ctx context.Context, plan SecurityRole, declaredPermissions types.List, roleId int) *api.UpdateSecurityRoleArg {
+// comment for why), and the role's current state permissions to fall back to
+// when the attribute is undeclared.
+//
+// Command's PUT /Security/Roles is a full-replace endpoint, NOT a merge
+// patch: confirmed live against a real Command instance, a PUT body that
+// simply omits the "Permissions" key entirely (as opposed to sending
+// "Permissions": null) still resets the role's permissions to an empty list
+// server-side. (This differs from how Command treats Enabled/Private, which
+// ARE preserved when omitted -- Permissions gets special-cased clear-if-absent
+// handling server-side.) So leaving the Permissions field nil/omitted on the
+// request can never mean "leave unchanged" for this endpoint; the only way to
+// preserve the role's existing permissions across an Update that omits
+// `permissions` from config is to resend them explicitly from state.
+//
+// A Null declaredPermissions value means the user omitted the attribute, so
+// statePermissions (the role's last-known permissions) is sent instead. An
+// explicit empty list is a real clear signal and is sent as `[]`.
+func buildSecurityRoleUpdateArg(ctx context.Context, plan SecurityRole, declaredPermissions types.List, statePermissions types.List, roleId int) *api.UpdateSecurityRoleArg {
 	arg := &api.UpdateSecurityRoleArg{
 		Id: roleId,
 		CreateSecurityRoleArg: api.CreateSecurityRoleArg{
@@ -134,15 +143,21 @@ func buildSecurityRoleUpdateArg(ctx context.Context, plan SecurityRole, declared
 			Description: plan.Description.Value,
 		},
 	}
-	if !declaredPermissions.Null && !declaredPermissions.Unknown {
-		permissions := []string{}
-		declaredPermissions.ElementsAs(ctx, &permissions, false)
-		if permissions == nil {
-			permissions = []string{}
-		}
-		sort.Strings(permissions)
-		arg.Permissions = &permissions
+
+	permsSource := declaredPermissions
+	if permsSource.Null || permsSource.Unknown {
+		permsSource = statePermissions
 	}
+
+	permissions := []string{}
+	if !permsSource.Null && !permsSource.Unknown {
+		permsSource.ElementsAs(ctx, &permissions, false)
+	}
+	if permissions == nil {
+		permissions = []string{}
+	}
+	sort.Strings(permissions)
+	arg.Permissions = &permissions
 	return arg
 }
 
@@ -258,8 +273,13 @@ func (r resourceSecurityRole) Update(
 	roleId := state.ID.Value
 	tflog.SetField(ctx, "id", roleId)
 
-	// Generate API request body from plan
-	updateArg := buildSecurityRoleUpdateArg(ctx, plan, config.Permissions, int(roleId))
+	// Generate API request body from plan. state.Permissions is passed so that
+	// when config.Permissions is undeclared, buildSecurityRoleUpdateArg can
+	// resend the role's current permissions explicitly rather than omitting
+	// the field -- Command's PUT endpoint clears permissions when the field
+	// is absent, it does not treat absence as "leave unchanged" (see
+	// buildSecurityRoleUpdateArg's doc comment).
+	updateArg := buildSecurityRoleUpdateArg(ctx, plan, config.Permissions, state.Permissions, int(roleId))
 
 	remoteState, err := r.p.client.UpdateSecurityRole(updateArg)
 	if err != nil {

--- a/keyfactor/resource_keyfactor_security_role_test.go
+++ b/keyfactor/resource_keyfactor_security_role_test.go
@@ -3,12 +3,18 @@ package keyfactor
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/stretchr/testify/assert"
 )
 
 type roleTestCase struct {
@@ -199,6 +205,215 @@ resource "keyfactor_role" "unit_test" {
 			},
 		},
 	})
+}
+
+// TestUnitKeyfactorSecurityRoleResource_UpdateOmittingPermissionsPreservesThem
+// drives a REAL Terraform Core plan/apply/refresh cycle (resource.UnitTest +
+// ProtoV6ProviderFactories, the same shape as TestUnitKeyfactorIdentityResource
+// in resource_keyfactor_security_identity_test.go) reproducing the exact
+// scenario found validating PR179 live against a real lab:
+//
+//  1. Create a role with permissions declared in config.
+//  2. Apply again with an unrelated attribute (description) changed and
+//     `permissions` omitted from config entirely.
+//
+// This must NOT fail with "Provider produced inconsistent result after
+// apply" -- permissions is Optional+Computed with a UseStateForUnknown plan
+// modifier, so Terraform Core commits at plan time (step 2) to the prior
+// state's permissions value; if Update() then returns anything else, Core
+// itself rejects the apply. And the resulting state must show permissions
+// genuinely preserved server-side, not silently cleared -- the full-replace
+// PUT fix in buildSecurityRoleUpdateArg (see its doc comment in
+// resource_keyfactor_security_role.go).
+//
+// Unlike TestUnitKeyfactorSecurityRoleResource above, this test is backed by
+// a hand-built httptest mock server, not a VCR cassette: makeVCRMatcher
+// matches replayed interactions on method+path+query ONLY (see its doc
+// comment in test_helpers_test.go) -- it deliberately ignores request
+// bodies, so a cassette replay can never assert what body the provider
+// actually sent, only script what the mock server responds with regardless.
+// The mock server here inspects the real PUT request body Update() sends and
+// mimics Command's actual full-replace semantics (confirmed live against
+// int25-4-1.kftestlab.com while validating PR179): an absent OR null
+// "Permissions" key clears permissions to [] server-side; it is never
+// treated as "leave unchanged".
+//
+// Red/green: reverting resource_keyfactor_security_role.go's
+// buildSecurityRoleUpdateArg to the pre-fix 3-argument form (no
+// statePermissions fallback -- see commit a0cd2f5) makes step 2's PUT body
+// omit "Permissions" entirely. The mock server mimics Command by clearing
+// permissions to [] in that case, which the schema's UseStateForUnknown
+// modifier already committed Core to expect as ["Certificates:Read"] --
+// Terraform Core itself then fails step 2's apply with "Provider produced
+// inconsistent result after apply: .permissions: was ..., but now ...",
+// exactly the class of bug this test guards against. This was confirmed by
+// temporarily stashing the fix and re-running this test.
+func TestUnitKeyfactorSecurityRoleResource_UpdateOmittingPermissionsPreservesThem(t *testing.T) {
+	const roleID = 4242
+	roleName := "tf-unit-role-preserve-perms"
+
+	// currentPermissions/currentDescription model the mock server's
+	// persisted role state across the two apply steps below, so GET
+	// (refresh) always reflects the most recent POST/PUT.
+	currentPermissions := []string{"Certificates:Read"}
+	currentDescription := "Initial description"
+
+	var lastPutBody map[string]interface{}
+	sawPermissionsKeyOnLastPut := false
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/KeyfactorAPI/Security/Roles", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			var body struct {
+				Name        string    `json:"Name"`
+				Description string    `json:"Description"`
+				Permissions *[]string `json:"Permissions"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			currentDescription = body.Description
+			if body.Permissions != nil {
+				currentPermissions = *body.Permissions
+			} else {
+				currentPermissions = []string{}
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"Id":          roleID,
+				"Name":        roleName,
+				"Description": currentDescription,
+				"Permissions": currentPermissions,
+			})
+		case http.MethodPut:
+			raw, _ := io.ReadAll(r.Body)
+
+			var rawMap map[string]interface{}
+			_ = json.Unmarshal(raw, &rawMap)
+			lastPutBody = rawMap
+			_, sawPermissionsKeyOnLastPut = rawMap["Permissions"]
+
+			// Mimic Command's real PUT /Security/Roles full-replace
+			// semantics: an absent OR null Permissions key clears
+			// permissions to [] -- it is never "leave unchanged".
+			var decoded struct {
+				Description string    `json:"Description"`
+				Permissions *[]string `json:"Permissions"`
+			}
+			_ = json.Unmarshal(raw, &decoded)
+			currentDescription = decoded.Description
+			if decoded.Permissions != nil {
+				currentPermissions = *decoded.Permissions
+			} else {
+				currentPermissions = []string{}
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"Id":          roleID,
+				"Name":        roleName,
+				"Description": currentDescription,
+				"Permissions": currentPermissions,
+			})
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+	mux.HandleFunc(fmt.Sprintf("/KeyfactorAPI/Security/Roles/%d", roleID), func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"Id":          roleID,
+				"Name":        roleName,
+				"Description": currentDescription,
+				"Permissions": currentPermissions,
+			})
+		case http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	p := &provider{testAuth: newCertAPIMockAuthConfig(server)}
+	factories := map[string]func() (tfprotov6.ProviderServer, error){
+		"keyfactor": providerserver.NewProtocol6WithError(p),
+	}
+
+	resourceName := "keyfactor_role.preserve_perms"
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: factories,
+		Steps: []resource.TestStep{
+			// Step 1: create with permissions declared in config.
+			{
+				Config: fmt.Sprintf(`
+resource "keyfactor_role" "preserve_perms" {
+	name        = %q
+	description = "Initial description"
+	permissions = ["Certificates:Read"]
+}
+`, roleName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Initial description"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.0", "Certificates:Read"),
+				),
+			},
+			// Step 2: change an unrelated attribute (description) and omit
+			// `permissions` from config entirely. Must NOT fail with
+			// "Provider produced inconsistent result after apply", and
+			// permissions must still be ["Certificates:Read"] afterward --
+			// not cleared.
+			{
+				Config: fmt.Sprintf(`
+resource "keyfactor_role" "preserve_perms" {
+	name        = %q
+	description = "Updated description, unrelated to permissions"
+}
+`, roleName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated description, unrelated to permissions"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.0", "Certificates:Read"),
+				),
+			},
+		},
+	})
+
+	if lastPutBody == nil {
+		t.Fatalf("expected the mock PUT /Security/Roles endpoint to have captured a request body, got none")
+	}
+	if !sawPermissionsKeyOnLastPut {
+		t.Fatalf(
+			"step 2's PUT /Security/Roles request omitted the \"Permissions\" key entirely -- Command's PUT " +
+				"endpoint is a full-replace, so omitting the field (not just sending null) clears the role's " +
+				"permissions server-side; buildSecurityRoleUpdateArg must resend state.Permissions explicitly " +
+				"when config.Permissions is undeclared",
+		)
+	}
+
+	var gotPermissions []string
+	if permsValue, ok := lastPutBody["Permissions"].([]interface{}); ok {
+		for _, v := range permsValue {
+			if s, ok := v.(string); ok {
+				gotPermissions = append(gotPermissions, s)
+			}
+		}
+	}
+	assert.Equal(
+		t, []string{"Certificates:Read"}, gotPermissions,
+		"step 2's PUT body must explicitly resend the role's prior permissions, not send null/omit the field",
+	)
 }
 
 func testAccKeyfactorRoleResourceConfig(t roleTestCase) string {

--- a/keyfactor/resource_keyfactor_security_role_unit_test.go
+++ b/keyfactor/resource_keyfactor_security_role_unit_test.go
@@ -13,24 +13,46 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestUnitSecurityRoleUpdateArgPermissions is a regression test for the bug
-// where a Null (undeclared) permissions attribute resolved to a nil Go slice
-// that was still wrapped in a non-nil pointer (&permissions). The non-nil
-// pointer bypassed the SDK's `omitempty`, so the request marshaled as
-// `"Permissions": null` and cleared every permission the role had. permissions
-// is Optional (not Computed): Null must omit the field (preserve), while an
-// explicit empty list must be sent as [] (clear).
+// TestUnitSecurityRoleUpdateArgPermissions is a regression test for two
+// distinct bugs found in buildSecurityRoleUpdateArg, in order of discovery:
+//
+//  1. (original) A Null (undeclared) permissions attribute resolved to a nil
+//     Go slice that was still wrapped in a non-nil pointer (&permissions).
+//     The non-nil pointer bypassed the SDK's `omitempty`, so the request
+//     marshaled as `"Permissions": null` and cleared every permission the
+//     role had.
+//  2. (found validating PR179 live against a real Command instance, NOT
+//     catchable by any mock/VCR test that doesn't model the server's actual
+//     merge semantics) Command's PUT /Security/Roles is a full-replace
+//     endpoint: omitting the "Permissions" key from the request body
+//     entirely -- not just avoiding an explicit null -- STILL resets the
+//     role's permissions to an empty list server-side. Unlike Enabled/Private
+//     (which Command preserves when omitted), Permissions gets clear-if-absent
+//     handling. So "omit the field to preserve" was never actually true for
+//     this endpoint; the only way to genuinely preserve permissions across an
+//     Update that omits `permissions` from config is to resend the role's
+//     current (state) permissions explicitly. buildSecurityRoleUpdateArg now
+//     takes the state's permissions as a fallback for exactly this.
 func TestUnitSecurityRoleUpdateArgPermissions(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("undeclared permissions omits the field (preserve)", func(t *testing.T) {
+	statePermissions := types.List{ElemType: types.StringType, Elems: []attr.Value{
+		types.String{Value: "certificates:read"},
+		types.String{Value: "auditing:read"},
+	}}
+
+	t.Run("undeclared permissions resends state permissions (preserve)", func(t *testing.T) {
 		plan := SecurityRole{
 			Name:        types.String{Value: "role"},
 			Permissions: types.List{Null: true, ElemType: types.StringType},
 		}
-		arg := buildSecurityRoleUpdateArg(ctx, plan, plan.Permissions, 5)
-		assert.Nil(t, arg.Permissions,
-			"undeclared permissions must be omitted so Command preserves the role's existing permissions")
+		declared := types.List{Null: true, ElemType: types.StringType}
+		arg := buildSecurityRoleUpdateArg(ctx, plan, declared, statePermissions, 5)
+		if assert.NotNil(t, arg.Permissions,
+			"undeclared permissions must still be sent explicitly -- Command's PUT clears permissions when the field is absent, it does not preserve them") {
+			assert.ElementsMatch(t, []string{"certificates:read", "auditing:read"}, *arg.Permissions,
+				"undeclared permissions must resend the role's current state permissions, not omit the field")
+		}
 	})
 
 	t.Run("explicit empty list clears", func(t *testing.T) {
@@ -38,10 +60,10 @@ func TestUnitSecurityRoleUpdateArgPermissions(t *testing.T) {
 			Name:        types.String{Value: "role"},
 			Permissions: types.List{ElemType: types.StringType, Elems: []attr.Value{}},
 		}
-		arg := buildSecurityRoleUpdateArg(ctx, plan, plan.Permissions, 5)
+		arg := buildSecurityRoleUpdateArg(ctx, plan, plan.Permissions, statePermissions, 5)
 		if assert.NotNil(t, arg.Permissions, "explicit permissions=[] must be sent as a clear signal") {
 			assert.Equal(t, []string{}, *arg.Permissions,
-				"an explicit empty permissions list must serialize as [] (clear), not null")
+				"an explicit empty permissions list must serialize as [] (clear), not preserved from state")
 		}
 	})
 
@@ -53,7 +75,7 @@ func TestUnitSecurityRoleUpdateArgPermissions(t *testing.T) {
 				types.String{Value: "auditing:read"},
 			}},
 		}
-		arg := buildSecurityRoleUpdateArg(ctx, plan, plan.Permissions, 5)
+		arg := buildSecurityRoleUpdateArg(ctx, plan, plan.Permissions, statePermissions, 5)
 		if assert.NotNil(t, arg.Permissions) {
 			assert.ElementsMatch(t, []string{"certificates:read", "auditing:read"}, *arg.Permissions)
 		}
@@ -499,21 +521,18 @@ func TestUnitSecurityRoleSchema_PermissionsIsComputedWithUseStateForUnknown(t *t
 // final value of a Known planned attribute must not change") -- not just "the
 // right permissions in some form."
 //
-// NOTE on red/green: unlike the schema test above, this one does NOT fail
-// against the pre-fix code, and that gap is itself informative. Pre-fix
-// Update() reads plan.Permissions directly (ignoring Config entirely) and
-// forwards it verbatim to the mock server, which echoes it back unchanged --
-// so the round trip is self-consistent regardless of which value (plan vs
-// config) drove the "declared" decision. The actual defect only exists one
-// layer up, in whether Terraform CORE's plan matches Update()'s return value
-// (see the schema test's comment and TestUnitKeyfactorIdentityResource in
-// resource_keyfactor_security_identity_test.go for a resource where a real
-// Core plan/apply cycle does catch this class of bug). This test is retained
-// as plumbing coverage for the Config-vs-Plan wiring introduced by the fix
-// (a future change that reverts to reading plan.Permissions for the
-// "declared" check would still pass it, by coincidence of this specific
-// scenario, but would fail the schema test's sibling concern if it also
-// dropped Computed/the plan modifier).
+// NOTE on red/green: this test's mock server models Command's REAL PUT
+// /Security/Roles full-replace semantics (confirmed live against
+// int25-4-1.kftestlab.com while validating PR179 end-to-end): a request body
+// that omits the "Permissions" key entirely is treated as clearing
+// permissions to [], not as "leave unchanged". An earlier version of this
+// mock unconditionally echoed back a fixed Permissions list regardless of
+// what the request actually sent, which made it pass even against the
+// original pre-fix buildSecurityRoleUpdateArg (nil/omitted Permissions on an
+// undeclared config) -- masking the exact data-loss bug a real Terraform
+// apply cycle against a live Command instance caught. With the body-aware
+// mock below, this test now genuinely fails if buildSecurityRoleUpdateArg
+// omits Permissions instead of resending the state's current permissions.
 //
 // The server response deliberately matches the prior state's permission set
 // exactly (same set, different case-preserved order is irrelevant here since
@@ -526,12 +545,25 @@ func TestUnitSecurityRoleResource_UpdatePreservesPermissionsWhenConfigOmitsThem(
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/KeyfactorAPI/Security/Roles", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Permissions *[]string `json:"Permissions"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+
+		// Mimic Command's real full-replace behavior: an absent/null
+		// Permissions key clears permissions to an empty list; the field is
+		// never treated as "leave unchanged".
+		permissions := []string{}
+		if body.Permissions != nil {
+			permissions = *body.Permissions
+		}
+
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"Id":          5,
 			"Name":        "tf-unit-role-preserve",
 			"Description": "Updated description, unrelated to permissions",
-			"Permissions": []string{"Certificates:Read"},
+			"Permissions": permissions,
 		})
 	})
 	server := httptest.NewTLSServer(mux)

--- a/keyfactor/resource_keyfactor_security_role_unit_test.go
+++ b/keyfactor/resource_keyfactor_security_role_unit_test.go
@@ -28,7 +28,7 @@ func TestUnitSecurityRoleUpdateArgPermissions(t *testing.T) {
 			Name:        types.String{Value: "role"},
 			Permissions: types.List{Null: true, ElemType: types.StringType},
 		}
-		arg := buildSecurityRoleUpdateArg(ctx, plan, 5)
+		arg := buildSecurityRoleUpdateArg(ctx, plan, plan.Permissions, 5)
 		assert.Nil(t, arg.Permissions,
 			"undeclared permissions must be omitted so Command preserves the role's existing permissions")
 	})
@@ -38,7 +38,7 @@ func TestUnitSecurityRoleUpdateArgPermissions(t *testing.T) {
 			Name:        types.String{Value: "role"},
 			Permissions: types.List{ElemType: types.StringType, Elems: []attr.Value{}},
 		}
-		arg := buildSecurityRoleUpdateArg(ctx, plan, 5)
+		arg := buildSecurityRoleUpdateArg(ctx, plan, plan.Permissions, 5)
 		if assert.NotNil(t, arg.Permissions, "explicit permissions=[] must be sent as a clear signal") {
 			assert.Equal(t, []string{}, *arg.Permissions,
 				"an explicit empty permissions list must serialize as [] (clear), not null")
@@ -53,7 +53,7 @@ func TestUnitSecurityRoleUpdateArgPermissions(t *testing.T) {
 				types.String{Value: "auditing:read"},
 			}},
 		}
-		arg := buildSecurityRoleUpdateArg(ctx, plan, 5)
+		arg := buildSecurityRoleUpdateArg(ctx, plan, plan.Permissions, 5)
 		if assert.NotNil(t, arg.Permissions) {
 			assert.ElementsMatch(t, []string{"certificates:read", "auditing:read"}, *arg.Permissions)
 		}
@@ -120,10 +120,20 @@ func TestUnitSecurityRoleResource_UpdatePreservesPlanPermissionsOrder(t *testing
 	if d := stateObj.Set(ctx, &state); d.HasError() {
 		t.Fatalf("test setup: state.Set returned diagnostics: %+v", d)
 	}
+	// Config mirrors the plan here (permissions is explicitly declared) --
+	// Update() now reads request.Config to distinguish "declared" from
+	// "omitted", since permissions is Optional+Computed (see
+	// permissionsResultForUpdate's doc comment).
+	config := plan
+	configPlan := tfsdk.Plan{Schema: schema}
+	if d := configPlan.Set(ctx, &config); d.HasError() {
+		t.Fatalf("test setup: config.Set returned diagnostics: %+v", d)
+	}
+	configObj := tfsdk.Config{Schema: schema, Raw: configPlan.Raw}
 
 	r := resourceSecurityRole{p: provider{configured: true, client: client}}
 
-	req := tfsdk.UpdateResourceRequest{Plan: planObj, State: stateObj}
+	req := tfsdk.UpdateResourceRequest{Config: configObj, Plan: planObj, State: stateObj}
 	resp := &tfsdk.UpdateResourceResponse{State: tfsdk.State{Schema: schema}}
 
 	r.Update(ctx, req, resp)
@@ -154,7 +164,7 @@ func TestUnitSecurityRoleResource_UpdatePreservesPlanPermissionsOrder(t *testing
 // TestUnitSecurityRoleResource_UpdateSurfacesRealServerDrift is the companion
 // regression test to TestUnitSecurityRoleResource_UpdatePreservesPlanPermissionsOrder:
 // unconditionally echoing plan.Permissions back into state (to avoid the
-// ordering-drift bug above) also masks genuine server-side drift — e.g.
+// ordering-drift bug above) also masks genuine server-side drift -- e.g.
 // Command rejecting or dropping a permission during Update. When the
 // server's response Permissions is NOT the same set as the plan's declared
 // permissions (regardless of order), Update() must write the server's
@@ -207,10 +217,20 @@ func TestUnitSecurityRoleResource_UpdateSurfacesRealServerDrift(t *testing.T) {
 	if d := stateObj.Set(ctx, &state); d.HasError() {
 		t.Fatalf("test setup: state.Set returned diagnostics: %+v", d)
 	}
+	// Config mirrors the plan here (permissions is explicitly declared) --
+	// Update() now reads request.Config to distinguish "declared" from
+	// "omitted", since permissions is Optional+Computed (see
+	// permissionsResultForUpdate's doc comment).
+	config := plan
+	configPlan := tfsdk.Plan{Schema: schema}
+	if d := configPlan.Set(ctx, &config); d.HasError() {
+		t.Fatalf("test setup: config.Set returned diagnostics: %+v", d)
+	}
+	configObj := tfsdk.Config{Schema: schema, Raw: configPlan.Raw}
 
 	r := resourceSecurityRole{p: provider{configured: true, client: client}}
 
-	req := tfsdk.UpdateResourceRequest{Plan: planObj, State: stateObj}
+	req := tfsdk.UpdateResourceRequest{Config: configObj, Plan: planObj, State: stateObj}
 	resp := &tfsdk.UpdateResourceResponse{State: tfsdk.State{Schema: schema}}
 
 	r.Update(ctx, req, resp)
@@ -403,5 +423,194 @@ func TestUnitSecurityRoleResource_ReadPreservesPermissionsOrderWhenUnchanged(t *
 	assert.Equal(
 		t, []string{"Certificates:Read", "Certificates:EditMetadata"}, permissions,
 		"Read() must preserve prior state's declared permissions order when the server's set is unchanged, not write back a re-sorted server copy",
+	)
+}
+
+// TestUnitSecurityRoleSchema_PermissionsIsComputedWithUseStateForUnknown is a
+// regression test for "Provider produced inconsistent result after apply:
+// .permissions: was null, but now cty.ListVal(...)" -- the identical defect to
+// the one fixed for keyfactor_identity's `roles` attribute (see
+// TestUnitSecurityIdentitySchema_RolesIsComputedWithUseStateForUnknown in
+// resource_keyfactor_security_identity_unit_test.go).
+//
+// permissions was Optional but NOT Computed. permissionsResultForUpdate (used
+// by Update()) deliberately writes a concrete, non-null permissions list into
+// the result whenever the config omits permissions, to preserve the role's
+// existing permissions across an unrelated Update. But for a non-Computed
+// attribute, Terraform Core plans directly from config with no path for a
+// provider-side plan modifier to intervene, so an omitted-from-config
+// permissions attribute always plans as Null. Any role with permissions
+// already assigned then failed apply with "Provider produced inconsistent
+// result after apply" on any unrelated Update.
+//
+// Why this shipped: this repo's TestUnit* harness for this resource
+// (TestUnitSecurityRoleResource_UpdatePreservesPlanPermissionsOrder etc.,
+// above) calls resourceSecurityRole's methods directly via hand-built
+// tfsdk.Plan/tfsdk.State values -- it never drives a real Terraform Core
+// plan/apply cycle, so a schema-shape defect like this one is invisible to
+// it (Update()'s return value looks correct in isolation). Unlike
+// TestUnitKeyfactorIdentityResource, this resource's one VCR-backed
+// resource.UnitTest (TestUnitKeyfactorSecurityRoleResource) never has a step
+// that omits permissions from config -- extending its cassette would require
+// recording a new interaction against a live lab, out of scope for this fix.
+// The strongest regression test achievable without that is asserting the
+// schema fix directly, mirroring
+// TestUnitTemplateSchema_V25CleanupFieldsUseStateForUnknown's approach for
+// the same bug class on a different resource.
+func TestUnitSecurityRoleSchema_PermissionsIsComputedWithUseStateForUnknown(t *testing.T) {
+	ctx := context.Background()
+
+	schema, diags := resourceSecurityRoleType{}.GetSchema(ctx)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics building schema: %v", diags)
+	}
+
+	attribute, ok := schema.Attributes["permissions"]
+	if !ok {
+		t.Fatalf("expected schema attribute %q to exist", "permissions")
+	}
+
+	if !attribute.Optional || !attribute.Computed {
+		t.Fatalf("attribute %q: expected Optional+Computed, got Optional=%v Computed=%v", "permissions", attribute.Optional, attribute.Computed)
+	}
+
+	found := false
+	for _, m := range attribute.PlanModifiers {
+		if _, ok := m.(tfsdk.UseStateForUnknownModifier); ok {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("attribute %q: expected UseStateForUnknown plan modifier so an omitted-from-config value carries forward from state instead of planning Null, but none was found (modifiers: %+v)", "permissions", attribute.PlanModifiers)
+	}
+}
+
+// TestUnitSecurityRoleResource_UpdatePreservesPermissionsWhenConfigOmitsThem
+// is a functional companion to the schema-level test above: it exercises the
+// real Update() path with a Config that omits permissions (Null) but a Plan
+// that already carries the prior state's permissions forward -- reproducing
+// exactly what UseStateForUnknownModifier hands Update() once the schema fix
+// is in place (see UseStateForUnknownModifier.Modify in
+// vendor/.../tfsdk/attribute_plan_modification.go: it copies AttributeState
+// into AttributePlan when AttributeConfig is null and AttributePlan is
+// unknown). It asserts Update()'s returned Permissions is IDENTICAL to the
+// planned value, which is the actual invariant Terraform Core enforces ("the
+// final value of a Known planned attribute must not change") -- not just "the
+// right permissions in some form."
+//
+// NOTE on red/green: unlike the schema test above, this one does NOT fail
+// against the pre-fix code, and that gap is itself informative. Pre-fix
+// Update() reads plan.Permissions directly (ignoring Config entirely) and
+// forwards it verbatim to the mock server, which echoes it back unchanged --
+// so the round trip is self-consistent regardless of which value (plan vs
+// config) drove the "declared" decision. The actual defect only exists one
+// layer up, in whether Terraform CORE's plan matches Update()'s return value
+// (see the schema test's comment and TestUnitKeyfactorIdentityResource in
+// resource_keyfactor_security_identity_test.go for a resource where a real
+// Core plan/apply cycle does catch this class of bug). This test is retained
+// as plumbing coverage for the Config-vs-Plan wiring introduced by the fix
+// (a future change that reverts to reading plan.Permissions for the
+// "declared" check would still pass it, by coincidence of this specific
+// scenario, but would fail the schema test's sibling concern if it also
+// dropped Computed/the plan modifier).
+//
+// The server response deliberately matches the prior state's permission set
+// exactly (same set, different case-preserved order is irrelevant here since
+// the plan/state list is already used verbatim): this isolates the
+// "undeclared config" code path from permissionsResultForUpdate's separate
+// drift-detection behavior, which is already covered by
+// TestUnitSecurityRoleResource_UpdateSurfacesRealServerDrift above.
+func TestUnitSecurityRoleResource_UpdatePreservesPermissionsWhenConfigOmitsThem(t *testing.T) {
+	ctx := context.Background()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/KeyfactorAPI/Security/Roles", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"Id":          5,
+			"Name":        "tf-unit-role-preserve",
+			"Description": "Updated description, unrelated to permissions",
+			"Permissions": []string{"Certificates:Read"},
+		})
+	})
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	client := newCertUpdateMockClient(server)
+
+	schema, sDiags := resourceSecurityRoleType{}.GetSchema(ctx)
+	if sDiags.HasError() {
+		t.Fatalf("GetSchema returned diagnostics: %+v", sDiags)
+	}
+
+	priorPermissions := types.List{ElemType: types.StringType, Elems: []attr.Value{
+		types.String{Value: "Certificates:Read"},
+	}}
+
+	state := SecurityRole{
+		ID:          types.Int64{Value: 5},
+		Name:        types.String{Value: "tf-unit-role-preserve"},
+		Description: types.String{Value: "Original description"},
+		Permissions: priorPermissions,
+	}
+
+	// The plan is what UseStateForUnknownModifier produces: the prior
+	// state's permissions copied forward because config is null and the raw
+	// plan was unknown. Only description changes, mirroring an unrelated
+	// Update.
+	plan := state
+	plan.Description = types.String{Value: "Updated description, unrelated to permissions"}
+
+	// The config is what the practitioner actually wrote: permissions is
+	// genuinely absent (Null).
+	config := SecurityRole{
+		ID:          state.ID,
+		Name:        state.Name,
+		Description: plan.Description,
+		Permissions: types.List{Null: true, ElemType: types.StringType},
+	}
+
+	stateObj := tfsdk.State{Schema: schema}
+	if d := stateObj.Set(ctx, &state); d.HasError() {
+		t.Fatalf("test setup: state.Set returned diagnostics: %+v", d)
+	}
+	planObj := tfsdk.Plan{Schema: schema}
+	if d := planObj.Set(ctx, &plan); d.HasError() {
+		t.Fatalf("test setup: plan.Set returned diagnostics: %+v", d)
+	}
+	configPlan := tfsdk.Plan{Schema: schema}
+	if d := configPlan.Set(ctx, &config); d.HasError() {
+		t.Fatalf("test setup: config.Set returned diagnostics: %+v", d)
+	}
+	configObj := tfsdk.Config{Schema: schema, Raw: configPlan.Raw}
+
+	r := resourceSecurityRole{p: provider{configured: true, client: client}}
+
+	req := tfsdk.UpdateResourceRequest{Config: configObj, Plan: planObj, State: stateObj}
+	resp := &tfsdk.UpdateResourceResponse{State: tfsdk.State{Schema: schema}}
+
+	r.Update(ctx, req, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Update returned unexpected diagnostics: %+v", resp.Diagnostics)
+	}
+
+	var result SecurityRole
+	if d := resp.State.Get(ctx, &result); d.HasError() {
+		t.Fatalf("reading back result state: %+v", d)
+	}
+
+	var gotPermissions []string
+	for _, e := range result.Permissions.Elems {
+		s, ok := e.(types.String)
+		if !ok {
+			t.Fatalf("expected permissions element to be types.String, got %T", e)
+		}
+		gotPermissions = append(gotPermissions, s.Value)
+	}
+
+	assert.Equal(
+		t, []string{"Certificates:Read"}, gotPermissions,
+		"Update() must write exactly the planned permissions into state when config omits the attribute -- Terraform Core already committed to this planned value, so any divergence is an inconsistent-result-after-apply error",
 	)
 }

--- a/keyfactor/resource_keyfactor_template_role_binding.go
+++ b/keyfactor/resource_keyfactor_template_role_binding.go
@@ -153,6 +153,10 @@ func (r resourceCertificateTemplateRoleBinding) Read(
 	diags = state.TemplateNames.ElementsAs(ctx, &templateNames, true)
 	kfTemplates, err := kfClient.GetTemplates()
 	if err != nil {
+		response.Diagnostics.AddError(
+			ERR_SUMMARY_TEMPLATE_READ,
+			"There was an error getting templates from Keyfactor Command: "+err.Error(),
+		)
 		return
 	}
 	validTemplateIds, apiDiags = verifyTemplateNames(ctx, kfTemplates, templateNames)

--- a/keyfactor/resource_keyfactor_template_role_binding_unit_test.go
+++ b/keyfactor/resource_keyfactor_template_role_binding_unit_test.go
@@ -214,3 +214,74 @@ func TestUnitTemplateRoleBindingRead_DetectsOutOfBandDetach(t *testing.T) {
 
 	assert.Equal(t, []string{"WebServer"}, names, "Read() must drop templates the role was detached from out-of-band, not echo back stale prior state")
 }
+
+// TestUnitTemplateRoleBindingRead_SurfacesGetTemplatesError is a regression
+// test for Read() silently swallowing a GetTemplates() API error:
+//
+//	kfTemplates, err := kfClient.GetTemplates()
+//	if err != nil {
+//		return
+//	}
+//
+// This returned with NO diagnostic and no logging, so a transient API failure
+// during Read (e.g. Command unreachable, auth expired) looked identical to a
+// completely successful, no-op refresh -- `terraform plan`/refresh would
+// silently keep stale state instead of surfacing the error, and worse, execution
+// would have fallen through to the un-set `state` if the early return had been
+// removed by a future edit. Create()'s identical GetTemplates() call already
+// handles this correctly (AddError + return); Read() must mirror it.
+//
+// This drives Read() end-to-end against a mock Command server whose /Templates
+// endpoint returns 500, and asserts response.Diagnostics.HasError() is true
+// with the same ERR_SUMMARY_TEMPLATE_READ summary Create() uses.
+func TestUnitTemplateRoleBindingRead_SurfacesGetTemplatesError(t *testing.T) {
+	ctx := context.Background()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/KeyfactorAPI/Templates/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"Message":"simulated Command outage"}`))
+	})
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	client := newCertUpdateMockClient(server)
+
+	schema, sDiags := resourceCertificateTemplateRoleBindingType{}.GetSchema(ctx)
+	if sDiags.HasError() {
+		t.Fatalf("GetSchema returned diagnostics: %+v", sDiags)
+	}
+
+	priorState := CertificateTemplateRoleBinding{
+		ID:       types.String{Value: "deadbeef"},
+		RoleName: types.String{Value: "tf-unit-role"},
+		TemplateNames: types.List{ElemType: types.StringType, Elems: []attr.Value{
+			types.String{Value: "WebServer"},
+		}},
+	}
+
+	stateObj := tfsdk.State{Schema: schema}
+	if d := stateObj.Set(ctx, &priorState); d.HasError() {
+		t.Fatalf("test setup: state.Set returned diagnostics: %+v", d)
+	}
+
+	r := resourceCertificateTemplateRoleBinding{p: provider{configured: true, client: client}}
+
+	req := tfsdk.ReadResourceRequest{State: stateObj}
+	resp := &tfsdk.ReadResourceResponse{State: tfsdk.State{Schema: schema}}
+
+	r.Read(ctx, req, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("Read() must surface a diagnostic when GetTemplates() fails, not silently return success")
+	}
+
+	found := false
+	for _, d := range resp.Diagnostics {
+		if d.Summary() == ERR_SUMMARY_TEMPLATE_READ {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected a diagnostic with summary %q (matching Create()'s handling of the same GetTemplates() error), got: %+v", ERR_SUMMARY_TEMPLATE_READ, resp.Diagnostics)
+}

--- a/keyfactor/test_helpers_test.go
+++ b/keyfactor/test_helpers_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"math/big"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -617,6 +618,59 @@ func (v *vcrAuthConfig) GetServerConfig() *auth_providers.Server {
 func (v *vcrAuthConfig) GetCommandVersion() string {
 	// VCR tests always target a v25+ lab; use the Applications endpoint.
 	return "25.1.0.0"
+}
+
+// mockAuthConfig implements the AuthConfig-shaped interfaces required by both
+// api.Client (keyfactor-go-client v3) and the keyfactor-go-client-sdk v24
+// v1/v2 API clients, backed by an httptest server. It replaces three
+// near-identical per-file mock AuthConfig types (certUpdateMockAuthConfig,
+// certDeployMockAuthConfig, oauthRoleClaimAssocMockAuthConfig) that
+// duplicated the same GetServerConfig/GetHttpClient/Authenticate/
+// GetCommandVersion bodies.
+//
+// apiPath and stripScheme cover the one real difference between the two
+// consumers: api.Client wants Host as a full URL (scheme included) plus an
+// explicit APIPath segment, while the SDK v24 clients' prepareRequest sets
+// url.Scheme = "https" itself and takes Host verbatim -- passing it a
+// scheme-prefixed URL would double up the scheme, so Host must be the bare
+// "host:port" form for that caller (see newSDKMockAuthConfig).
+type mockAuthConfig struct {
+	server      *httptest.Server
+	apiPath     string
+	stripScheme bool
+}
+
+func (m *mockAuthConfig) GetServerConfig() *auth_providers.Server {
+	host := m.server.URL
+	if m.stripScheme {
+		host = strings.TrimPrefix(host, "https://")
+	}
+	return &auth_providers.Server{
+		Host:          host,
+		APIPath:       m.apiPath,
+		SkipTLSVerify: true,
+	}
+}
+
+func (m *mockAuthConfig) GetHttpClient() (*http.Client, error) {
+	return m.server.Client(), nil
+}
+
+func (m *mockAuthConfig) Authenticate() error       { return nil }
+func (m *mockAuthConfig) GetCommandVersion() string { return "25.1.0.0" }
+
+// newCertAPIMockAuthConfig builds a mockAuthConfig suitable for api.Client
+// (keyfactor-go-client v3), which wants a scheme-prefixed Host plus an
+// explicit APIPath.
+func newCertAPIMockAuthConfig(server *httptest.Server) *mockAuthConfig {
+	return &mockAuthConfig{server: server, apiPath: "KeyfactorAPI"}
+}
+
+// newSDKMockAuthConfig builds a mockAuthConfig suitable for the
+// keyfactor-go-client-sdk v24 v1/v2 API clients, which want a bare
+// "host:port" Host with no scheme and no separate APIPath.
+func newSDKMockAuthConfig(server *httptest.Server) *mockAuthConfig {
+	return &mockAuthConfig{server: server, stripScheme: true}
 }
 
 // newVCRServer returns a fake *auth_providers.Server suitable for VCR replay.

--- a/terraform/certificate_authority_demo/GNUmakefile
+++ b/terraform/certificate_authority_demo/GNUmakefile
@@ -1,0 +1,78 @@
+## certificate_authority_demo/GNUmakefile
+##
+## Import/read smoke test for keyfactor_certificate_authority, covering PR
+## #179's enumPtrToTfInt64 refactor (enrollmentTypePtrToTfInt64,
+## keyRetentionPtrToTfInt64, cleanupTimeUnitsPtrToTfInt64 now delegate to the
+## shared generic helper). No behavior change was intended by that refactor.
+##
+## Deliberately IMPORT-ONLY: unlike this repo's other lab demos, this one
+## never creates or destroys a CA connection -- there is exactly one real CA
+## in this lab and fabricating a second risks confusing its PKI setup for no
+## benefit (the refactor only touches Read()'s enum conversion, which import
+## + a plan/refresh already exercises against the real, existing CA).
+##
+## Usage:
+##   cd terraform/certificate_authority_demo
+##   make build
+##   make init
+##   make lab-import-existing
+##   make lab-drift-check
+
+PROVIDER_ROOT  := $(abspath ../..)
+PROVIDER_BIN   := $(HOME)/go/bin
+
+TF            := TF_CLI_CONFIG_FILE=.terraformrc terraform
+UNSET_BASIC   := unset KEYFACTOR_USERNAME KEYFACTOR_PASSWORD KEYFACTOR_DOMAIN;
+
+SHELL         := /bin/bash
+LAB_ENV_FILE  ?= $(HOME)/.env_ses2541
+LAB_TIMEOUT   ?= 600
+CA_ID         ?= 1
+
+LAB_ENV := set -a && source $(LAB_ENV_FILE) && set +a && \
+           unset KEYFACTOR_USERNAME KEYFACTOR_PASSWORD KEYFACTOR_DOMAIN && \
+           export KEYFACTOR_CLIENT_TIMEOUT=$(LAB_TIMEOUT) &&
+
+## build: Compile and install the provider binary to ~/go/bin
+build:
+	@echo "==> Building provider..."
+	cd $(PROVIDER_ROOT) && go install .
+	@echo "==> Provider installed to $(PROVIDER_BIN)/terraform-provider-keyfactor"
+
+## init: Initialize the Terraform working directory
+init:
+	$(UNSET_BASIC) $(TF) init
+
+## validate: Validate the Terraform configuration
+validate:
+	$(UNSET_BASIC) $(TF) validate
+
+## import-existing: Import the real lab CA by ID
+import-existing:
+	$(UNSET_BASIC) $(TF) import keyfactor_certificate_authority.sub_ca $(CA_ID)
+
+## drift-check: Plan after import — shows any real drift, or fields this demo's
+##   minimal config doesn't fully match (Optional+Computed fields with
+##   UseStateForUnknown should show no diff; only genuinely-mismatched
+##   Optional fields not set in config would appear, which is expected/informative
+##   here since this demo intentionally doesn't mirror every attribute)
+drift-check:
+	$(UNSET_BASIC) $(TF) plan
+
+## show: Show the current state (enum fields of interest)
+show:
+	$(UNSET_BASIC) $(TF) output
+
+## clean: Remove generated files (never touches the real CA)
+clean:
+	rm -f tf_state.json terraform.tfstate terraform.tfstate.backup terraform.tfstate.*.backup
+
+## lab-import-existing: Import using lab credentials
+lab-import-existing:
+	$(LAB_ENV) $(MAKE) import-existing CA_ID=$(CA_ID)
+
+## lab-drift-check: Drift-check using lab credentials
+lab-drift-check:
+	$(LAB_ENV) $(MAKE) drift-check
+
+.PHONY: build init validate import-existing drift-check show clean lab-import-existing lab-drift-check

--- a/terraform/certificate_authority_demo/main.tf
+++ b/terraform/certificate_authority_demo/main.tf
@@ -1,0 +1,67 @@
+terraform {
+  required_providers {
+    keyfactor = {
+      source  = "keyfactor-pub/keyfactor"
+      version = ">= 2.0"
+    }
+  }
+}
+
+provider "keyfactor" {}
+
+# ---------------------------------------------------------------------------
+# keyfactor_certificate_authority import/read smoke test.
+#
+# This resource wasn't behaviorally changed by PR #179 -- only 3 of its
+# nil-pointer-to-Int64 enum converters (enrollmentTypePtrToTfInt64,
+# keyRetentionPtrToTfInt64, cleanupTimeUnitsPtrToTfInt64) were refactored to
+# delegate to the new shared generic helper enumPtrToTfInt64[T ~int32] in
+# helpers.go, replacing 3x5 lines of hand-duplicated logic with 3 one-line
+# calls. No behavior change was intended.
+#
+# Unlike the other PR #179 demos, this one deliberately does NOT create a
+# new CA registration from scratch: `keyfactor_certificate_authority` create
+# targets a real, already-configured CA connection (host/token/client
+# credentials), and there is exactly one real CA in this lab
+# (int25-4-1.kftestlab.com's "Sub-CA", CAType=1/EJBCA, discovered via
+# `make api-get-ca CA_ID=1`) -- fabricating a second one risks colliding with
+# or confusing the lab's actual PKI setup for no real benefit, since the
+# refactor only touches how Read() converts already-fetched enum values.
+#
+# Instead this demo IMPORTS the lab's existing CA and confirms the import +
+# subsequent Read/refresh round-trips its enrollment_type/key_retention/
+# cleanup_time_units fields correctly -- exactly the fields the refactored
+# converters handle -- without ever creating, updating, or destroying the
+# real CA connection.
+# ---------------------------------------------------------------------------
+resource "keyfactor_certificate_authority" "sub_ca" {
+  logical_name = var.logical_name
+  host_name    = var.host_name
+  ca_type      = var.ca_type
+
+  lifecycle {
+    # This demo only imports and reads; never plan a destroy/replace against
+    # the lab's one real CA connection.
+    prevent_destroy = true
+  }
+}
+
+output "ca_id" {
+  description = "ID of the certificate authority."
+  value       = keyfactor_certificate_authority.sub_ca.id
+}
+
+output "allowed_enrollment_types" {
+  description = "allowed_enrollment_types as read back into Terraform state (exercises enrollmentTypePtrToTfInt64)."
+  value       = keyfactor_certificate_authority.sub_ca.allowed_enrollment_types
+}
+
+output "key_retention" {
+  description = "key_retention as read back into Terraform state (exercises keyRetentionPtrToTfInt64)."
+  value       = keyfactor_certificate_authority.sub_ca.key_retention
+}
+
+output "time_after_expiration_units" {
+  description = "time_after_expiration_units as read back into Terraform state (exercises cleanupTimeUnitsPtrToTfInt64; expected null on this CA, which has certificate cleanup disabled)."
+  value       = keyfactor_certificate_authority.sub_ca.time_after_expiration_units
+}

--- a/terraform/certificate_authority_demo/variables.tf
+++ b/terraform/certificate_authority_demo/variables.tf
@@ -1,0 +1,17 @@
+variable "logical_name" {
+  type        = string
+  default     = "Sub-CA"
+  description = "Logical name of the existing lab CA to import (see `make api-list-cas-short`)."
+}
+
+variable "host_name" {
+  type        = string
+  default     = "http://ejbca-ca.int25-4-1.svc.cluster.local:8082/ejbca"
+  description = "Host name of the existing lab CA to import."
+}
+
+variable "ca_type" {
+  type        = number
+  default     = 1
+  description = "CA type of the existing lab CA to import (0=DCOM, 1=HTTPS/EJBCA)."
+}

--- a/terraform/pam_provider_type_demo/GNUmakefile
+++ b/terraform/pam_provider_type_demo/GNUmakefile
@@ -1,0 +1,132 @@
+## pam_provider_type_demo/GNUmakefile
+##
+## Full-lifecycle smoke test for keyfactor_pam_provider_type, covering PR
+## #179's enumPtrToTfInt64 refactor (pamParameterDataTypePtrToTfInt64 now
+## delegates to the shared generic helper instead of duplicating its body).
+## No behavior change was intended by that refactor; this demo proves the
+## real create/read/import round-trip for parameters[].data_type still works:
+##   build → init → validate → plan → apply → import → reconcile → drift-check → destroy
+##
+## Usage:
+##   cd terraform/pam_provider_type_demo
+##   make build              # compile + install the provider locally
+##   make init               # terraform init
+##   make lifecycle           # run the full lab lifecycle
+##   make SUFFIX=_MYORG lifecycle
+
+PROVIDER_ROOT  := $(abspath ../..)
+PROVIDER_BIN   := $(HOME)/go/bin
+SUFFIX         ?= _TF
+
+TF            := TF_CLI_CONFIG_FILE=.terraformrc terraform
+UNSET_BASIC   := unset KEYFACTOR_USERNAME KEYFACTOR_PASSWORD KEYFACTOR_DOMAIN;
+
+# ---------------------------------------------------------------------------
+# Lab environment helpers
+# ---------------------------------------------------------------------------
+SHELL         := /bin/bash
+LAB_ENV_FILE  ?= $(HOME)/.env_ses2541
+LAB_TIMEOUT   ?= 600
+
+LAB_ENV := set -a && source $(LAB_ENV_FILE) && set +a && \
+           unset KEYFACTOR_USERNAME KEYFACTOR_PASSWORD KEYFACTOR_DOMAIN && \
+           export KEYFACTOR_CLIENT_TIMEOUT=$(LAB_TIMEOUT) &&
+
+# ---------------------------------------------------------------------------
+# Provider build
+# ---------------------------------------------------------------------------
+
+## build: Compile and install the provider binary to ~/go/bin
+build:
+	@echo "==> Building provider..."
+	cd $(PROVIDER_ROOT) && go install .
+	@echo "==> Provider installed to $(PROVIDER_BIN)/terraform-provider-keyfactor"
+
+# ---------------------------------------------------------------------------
+# Terraform lifecycle
+# ---------------------------------------------------------------------------
+
+## init: Initialize the Terraform working directory
+init:
+	$(UNSET_BASIC) $(TF) init
+
+## validate: Validate the Terraform configuration
+validate:
+	$(UNSET_BASIC) $(TF) validate
+
+## plan: Show the execution plan
+plan:
+	$(UNSET_BASIC) $(TF) plan -var="suffix=$(SUFFIX)"
+
+## apply: Create the PAM provider type resource
+apply:
+	$(UNSET_BASIC) $(TF) apply -auto-approve -var="suffix=$(SUFFIX)"
+
+## import-all: Remove the managed resource from state then re-import by its real ID
+import-all:
+	@echo "==> Capturing state..."
+	$(UNSET_BASIC) $(TF) show -json > tf_state.json
+	@echo "==> Extracting ID from state..."
+	@PROVIDER_TYPE_ID=$$($(UNSET_BASIC) $(TF) output -raw pam_provider_type_id 2>/dev/null) && \
+	 echo "PAM Provider Type ID=$$PROVIDER_TYPE_ID" && \
+	 echo "==> Removing from state..." && \
+	 $(UNSET_BASIC) $(TF) state rm keyfactor_pam_provider_type.demo 2>&1 | grep -E "Removed|Successfully" || true && \
+	 echo "==> Re-importing by real ID..." && \
+	 $(UNSET_BASIC) $(TF) import -var="suffix=$(SUFFIX)" keyfactor_pam_provider_type.demo "$$PROVIDER_TYPE_ID"
+
+## reconcile: Apply after import to reconcile fields not returned by the API
+reconcile:
+	$(UNSET_BASIC) $(TF) apply -auto-approve -var="suffix=$(SUFFIX)"
+
+## drift-check: Plan after reconcile — should show "No changes"
+drift-check:
+	$(UNSET_BASIC) $(TF) plan -var="suffix=$(SUFFIX)"
+
+## destroy: Destroy the managed PAM provider type resource
+destroy:
+	$(UNSET_BASIC) $(TF) destroy -auto-approve -var="suffix=$(SUFFIX)"
+
+## clean: Remove generated files
+clean:
+	rm -f tf_state.json terraform.tfstate terraform.tfstate.backup terraform.tfstate.*.backup
+
+# ---------------------------------------------------------------------------
+# Combined workflows
+# ---------------------------------------------------------------------------
+
+## all: Full workflow — build, init, validate, plan, apply, import-all, reconcile, drift-check, destroy
+all: build init validate plan apply import-all reconcile drift-check destroy
+
+# ---------------------------------------------------------------------------
+# Lab convenience targets (source LAB_ENV_FILE automatically)
+# ---------------------------------------------------------------------------
+
+## lab-plan: Plan using lab credentials
+lab-plan:
+	$(LAB_ENV) $(MAKE) plan SUFFIX=$(SUFFIX)
+
+## lab-apply: Apply using lab credentials
+lab-apply:
+	$(LAB_ENV) $(MAKE) apply SUFFIX=$(SUFFIX)
+
+## lab-import-all: Import all resources using lab credentials
+lab-import-all:
+	$(LAB_ENV) $(MAKE) import-all SUFFIX=$(SUFFIX)
+
+## lab-reconcile: Reconcile after import
+lab-reconcile:
+	$(LAB_ENV) $(MAKE) reconcile SUFFIX=$(SUFFIX)
+
+## lab-drift-check: Drift-check using lab credentials
+lab-drift-check:
+	$(LAB_ENV) $(MAKE) drift-check SUFFIX=$(SUFFIX)
+
+## lab-destroy: Destroy all managed resources using lab credentials
+lab-destroy:
+	$(LAB_ENV) $(MAKE) destroy SUFFIX=$(SUFFIX)
+
+## lifecycle: Full lifecycle: apply → import-all → reconcile → drift-check → destroy
+lifecycle: lab-apply lab-import-all lab-reconcile lab-drift-check lab-destroy
+
+.PHONY: build init validate plan apply import-all reconcile drift-check destroy clean all \
+        lab-plan lab-apply lab-import-all lab-reconcile lab-drift-check lab-destroy lifecycle

--- a/terraform/pam_provider_type_demo/main.tf
+++ b/terraform/pam_provider_type_demo/main.tf
@@ -1,0 +1,56 @@
+terraform {
+  required_providers {
+    keyfactor = {
+      source  = "keyfactor-pub/keyfactor"
+      version = ">= 2.0"
+    }
+  }
+}
+
+provider "keyfactor" {}
+
+# ---------------------------------------------------------------------------
+# keyfactor_pam_provider_type full-lifecycle smoke test.
+#
+# This resource wasn't behaviorally changed by PR #179 -- only its
+# nil-pointer-to-Int64 DataType converter (pamParameterDataTypePtrToTfInt64)
+# was refactored to delegate to a new shared generic helper
+# (enumPtrToTfInt64[T ~int32] in helpers.go), replacing 5 lines of
+# hand-duplicated logic with a one-line call. No behavior change was
+# intended. This demo exists to prove that refactor didn't regress the real
+# create/read/import round-trip for the `parameters[].data_type` field,
+# which is exactly the field enumPtrToTfInt64 converts.
+# ---------------------------------------------------------------------------
+resource "keyfactor_pam_provider_type" "demo" {
+  name = "PamProviderTypeDemo${var.suffix}"
+
+  parameters = [
+    {
+      name           = "Hostname"
+      display_name   = "PAM Server Hostname"
+      data_type      = 1 # string
+      instance_level = false
+    },
+    {
+      name           = "Password"
+      display_name   = "PAM Account Password"
+      data_type      = 2 # secret
+      instance_level = false
+    },
+  ]
+}
+
+output "pam_provider_type_id" {
+  description = "ID of the created PAM provider type."
+  value       = keyfactor_pam_provider_type.demo.id
+}
+
+output "pam_provider_type_name" {
+  description = "Name of the created PAM provider type."
+  value       = keyfactor_pam_provider_type.demo.name
+}
+
+output "pam_provider_type_parameters" {
+  description = "Parameters currently in Terraform state for the PAM provider type."
+  value       = keyfactor_pam_provider_type.demo.parameters
+}

--- a/terraform/pam_provider_type_demo/variables.tf
+++ b/terraform/pam_provider_type_demo/variables.tf
@@ -1,0 +1,5 @@
+variable "suffix" {
+  type        = string
+  default     = "_TF"
+  description = "Suffix appended to resource names to avoid conflicts."
+}

--- a/terraform/security_identity_demo/GNUmakefile
+++ b/terraform/security_identity_demo/GNUmakefile
@@ -1,0 +1,217 @@
+## security_identity_demo/GNUmakefile
+##
+## Demonstrates end-to-end lifecycle of the legacy keyfactor_identity
+## resource, and proves PR #179 (make `roles` Optional+Computed to fix
+## "Provider produced inconsistent result after apply" when an Update omits
+## `roles` from config):
+##   build → init → validate → plan → apply → import → reconcile → drift-check → destroy
+##
+## The `lab-omit-roles-update` target is the actual regression proof for
+## PR #179: it applies the identity WITH roles declared, then applies again
+## with `roles` omitted from config entirely -- this must succeed without
+## the inconsistent-result crash, and the identity's role assignment must
+## remain present server-side afterward.
+##
+## LAB CONSTRAINT: keyfactor_identity manages Active Directory identities
+## only. The default lab (LAB_ENV_FILE, int25-4-1.kftestlab.com) is
+## OAuth/EJBCA-backed with no AD, so `apply` here fails at Create with HTTP
+## 400 "This operation only supports Active Directory identities" for ANY
+## account_name -- confirmed directly against the Command REST API. Point
+## account_name at a real AD-backed lab account (not yet a Keyfactor
+## security identity) to exercise this demo end-to-end; see
+## discoverCreatableIdentity in
+## keyfactor/resource_keyfactor_security_identity_test.go for the pattern
+## this repo's integration tests use.
+##
+## Usage:
+##   cd terraform/security_identity_demo
+##   make build              # compile + install the provider locally
+##   make init               # terraform init
+##   make ACCOUNT_NAME='DOMAIN\\user' all   # run against an AD-backed lab
+##   make SUFFIX=_MYORG all  # run with a custom name suffix
+
+PROVIDER_ROOT  := $(abspath ../..)
+PROVIDER_BIN   := $(HOME)/go/bin
+SUFFIX         ?= _TF
+ACCOUNT_NAME   ?= KEYFACTOR\\Administrator
+
+TF            := TF_CLI_CONFIG_FILE=.terraformrc terraform
+UNSET_BASIC   := unset KEYFACTOR_USERNAME KEYFACTOR_PASSWORD KEYFACTOR_DOMAIN;
+
+# ---------------------------------------------------------------------------
+# Lab environment helpers
+# Source LAB_ENV_FILE for OAuth credentials.
+# Override via: make LAB_ENV_FILE=~/.env_other lifecycle
+# ---------------------------------------------------------------------------
+SHELL         := /bin/bash
+LAB_ENV_FILE  ?= $(HOME)/.env_ses2541
+LAB_TIMEOUT   ?= 600
+
+LAB_ENV := set -a && source $(LAB_ENV_FILE) && set +a && \
+           unset KEYFACTOR_USERNAME KEYFACTOR_PASSWORD KEYFACTOR_DOMAIN && \
+           export KEYFACTOR_CLIENT_TIMEOUT=$(LAB_TIMEOUT) &&
+
+# ---------------------------------------------------------------------------
+# Provider build
+# ---------------------------------------------------------------------------
+
+## build: Compile and install the provider binary to ~/go/bin
+build:
+	@echo "==> Building provider..."
+	cd $(PROVIDER_ROOT) && go install .
+	@echo "==> Provider installed to $(PROVIDER_BIN)/terraform-provider-keyfactor"
+
+# ---------------------------------------------------------------------------
+# Terraform lifecycle
+# ---------------------------------------------------------------------------
+
+## init: Initialize the Terraform working directory
+init:
+	$(UNSET_BASIC) $(TF) init
+
+## validate: Validate the Terraform configuration
+validate:
+	$(UNSET_BASIC) $(TF) validate
+
+## plan: Show the execution plan
+plan:
+	$(UNSET_BASIC) $(TF) plan -var="suffix=$(SUFFIX)" -var="account_name=$(ACCOUNT_NAME)"
+
+## apply: Create the security identity resource
+apply:
+	$(UNSET_BASIC) $(TF) apply -auto-approve -var="suffix=$(SUFFIX)" -var="account_name=$(ACCOUNT_NAME)"
+
+## import-all: Remove the managed resource from state then re-import by its real account name
+import-all:
+	@echo "==> Capturing state..."
+	$(UNSET_BASIC) $(TF) show -json > tf_state.json
+	@echo "==> Extracting account name from state..."
+	@ACCT=$$($(UNSET_BASIC) $(TF) output -raw identity_account_name 2>/dev/null) && \
+	 echo "Account Name=$$ACCT" && \
+	 echo "==> Removing from state..." && \
+	 $(UNSET_BASIC) $(TF) state rm keyfactor_identity.demo 2>&1 | grep -E "Removed|Successfully" || true && \
+	 echo "==> Re-importing by real account name..." && \
+	 $(UNSET_BASIC) $(TF) import -var="suffix=$(SUFFIX)" -var="account_name=$(ACCOUNT_NAME)" keyfactor_identity.demo "$$ACCT"
+
+## reconcile: Apply after import to reconcile fields not returned by the API
+reconcile:
+	$(UNSET_BASIC) $(TF) apply -auto-approve -var="suffix=$(SUFFIX)" -var="account_name=$(ACCOUNT_NAME)"
+
+## drift-check: Plan after reconcile — should show "No changes"
+drift-check:
+	$(UNSET_BASIC) $(TF) plan -var="suffix=$(SUFFIX)" -var="account_name=$(ACCOUNT_NAME)"
+
+## destroy: Destroy the managed security identity resource
+destroy:
+	$(UNSET_BASIC) $(TF) destroy -auto-approve -var="suffix=$(SUFFIX)" -var="account_name=$(ACCOUNT_NAME)"
+
+## clean: Remove generated files
+clean:
+	rm -f tf_state.json terraform.tfstate terraform.tfstate.backup terraform.tfstate.*.backup
+
+# ---------------------------------------------------------------------------
+# Combined workflows
+# ---------------------------------------------------------------------------
+
+## all: Full workflow — build, init, validate, plan, apply, import-all, reconcile, drift-check, destroy
+all: build init validate plan apply import-all reconcile drift-check destroy
+
+## demo-no-destroy: Run workflow without final destroy (leaves resources on server)
+demo-no-destroy: build init validate plan apply import-all reconcile drift-check
+
+# ---------------------------------------------------------------------------
+# Lab convenience targets (source LAB_ENV_FILE automatically)
+# ---------------------------------------------------------------------------
+
+## lab-plan: Plan using lab credentials
+lab-plan:
+	$(LAB_ENV) $(MAKE) plan SUFFIX=$(SUFFIX) ACCOUNT_NAME='$(ACCOUNT_NAME)'
+
+## lab-apply: Apply using lab credentials
+lab-apply:
+	$(LAB_ENV) $(MAKE) apply SUFFIX=$(SUFFIX) ACCOUNT_NAME='$(ACCOUNT_NAME)'
+
+## lab-import-all: Import all resources using lab credentials
+lab-import-all:
+	$(LAB_ENV) $(MAKE) import-all SUFFIX=$(SUFFIX) ACCOUNT_NAME='$(ACCOUNT_NAME)'
+
+## lab-reconcile: Reconcile after import
+lab-reconcile:
+	$(LAB_ENV) $(MAKE) reconcile SUFFIX=$(SUFFIX) ACCOUNT_NAME='$(ACCOUNT_NAME)'
+
+## lab-drift-check: Drift-check using lab credentials
+lab-drift-check:
+	$(LAB_ENV) $(MAKE) drift-check SUFFIX=$(SUFFIX) ACCOUNT_NAME='$(ACCOUNT_NAME)'
+
+## lab-destroy: Destroy all managed resources using lab credentials
+lab-destroy:
+	$(LAB_ENV) $(MAKE) destroy SUFFIX=$(SUFFIX) ACCOUNT_NAME='$(ACCOUNT_NAME)'
+
+## lifecycle: Full lifecycle: apply → import-all → reconcile → drift-check → destroy
+lifecycle: lab-apply lab-import-all lab-reconcile lab-drift-check lab-destroy
+
+# ---------------------------------------------------------------------------
+# PR #179 regression proof — roles omitted on an Update
+#
+#   1. apply with roles declared (roles_declared=true)
+#   2. apply again with roles omitted from config (roles_declared=false) --
+#      pre-fix this crashed terraform apply with "Provider produced
+#      inconsistent result after apply: .roles: was null, but now
+#      cty.ListVal(...)"; post-fix this must succeed cleanly
+#   3. verify via a direct Command REST API call that the identity's roles
+#      are still intact server-side (preserved, not cleared)
+#   4. destroy
+#
+# NOTE: unlike keyfactor_role's lab-omit-permissions-update, this scenario
+# needs no unrelated-attribute change to force an Update call: the plan
+# diff on `roles` alone (list -> null, pre-fix) is what makes Terraform Core
+# call Update in the first place. keyfactor_identity has no other
+# user-settable attribute besides account_name (RequiresReplace).
+# ---------------------------------------------------------------------------
+
+## lab-omit-roles-update: Regression proof for PR179 (roles Optional+Computed fix)
+lab-omit-roles-update:
+	@echo "==> [1/4] apply WITH roles declared..."
+	$(LAB_ENV) $(TF) apply -auto-approve \
+	  -var="suffix=$(SUFFIX)" \
+	  -var="account_name=$(ACCOUNT_NAME)" \
+	  -var="roles_declared=true"
+	@echo "==> [2/4] apply again with roles OMITTED from config..."
+	@$(LAB_ENV) $(TF) apply -auto-approve -no-color \
+	  -var="suffix=$(SUFFIX)" \
+	  -var="account_name=$(ACCOUNT_NAME)" \
+	  -var="roles_declared=false" > /tmp/security_identity_demo_apply2.txt 2>&1; \
+	 APPLY_EXIT=$$?; \
+	 cat /tmp/security_identity_demo_apply2.txt; \
+	 if [ $$APPLY_EXIT -eq 0 ]; then \
+	   echo "PASS: apply succeeded with roles omitted on Update (PR179 fix confirmed)."; \
+	 else \
+	   echo "FAIL: apply failed (exit $$APPLY_EXIT) -- inconsistent-result-after-apply regression."; \
+	   exit 1; \
+	 fi
+	@echo "==> [3/4] verify roles are still intact server-side (direct Command API call)..."
+	@$(LAB_ENV) \
+	 ACCT=$$($(TF) output -raw identity_account_name) && \
+	 echo "    target identity: $$ACCT" && \
+	 TOKEN=$$(curl -sk -X POST "$$KEYFACTOR_AUTH_TOKEN_URL" \
+	   -d "grant_type=client_credentials&client_id=$$KEYFACTOR_AUTH_CLIENT_ID&client_secret=$$KEYFACTOR_AUTH_CLIENT_SECRET" \
+	   | jq -r '.access_token') && \
+	 curl -sk "https://$$KEYFACTOR_HOSTNAME/$${KEYFACTOR_API_PATH:-Keyfactor/API}/Security/Identities" \
+	   -H "x-keyfactor-requested-with: APIClient" \
+	   -H "x-keyfactor-api-version: 1" \
+	   -H "Authorization: Bearer $$TOKEN" > /tmp/security_identity_demo_verify.json && \
+	 jq --arg acct "$$ACCT" '.[] | select(.AccountName == $$acct)' /tmp/security_identity_demo_verify.json && \
+	 if jq -e --arg acct "$$ACCT" '.[] | select(.AccountName == $$acct) | .Roles | length > 0' /tmp/security_identity_demo_verify.json > /dev/null; then \
+	   echo "PASS: server-side roles are still present -- preserved, not cleared."; \
+	 else \
+	   echo "FAIL: server-side roles are empty -- roles were cleared."; \
+	   exit 1; \
+	 fi
+	@echo "==> [4/4] destroy..."
+	$(LAB_ENV) $(TF) destroy -auto-approve \
+	  -var="suffix=$(SUFFIX)" \
+	  -var="account_name=$(ACCOUNT_NAME)" \
+	  -var="roles_declared=false"
+
+.PHONY: build init validate plan apply import-all reconcile drift-check destroy clean all demo-no-destroy \
+        lab-plan lab-apply lab-import-all lab-reconcile lab-drift-check lab-destroy lifecycle lab-omit-roles-update

--- a/terraform/security_identity_demo/main.tf
+++ b/terraform/security_identity_demo/main.tf
@@ -1,0 +1,80 @@
+terraform {
+  required_providers {
+    keyfactor = {
+      source  = "keyfactor-pub/keyfactor"
+      version = ">= 2.0"
+    }
+  }
+}
+
+provider "keyfactor" {}
+
+# ---------------------------------------------------------------------------
+# Legacy Active Directory security identity (keyfactor_identity).
+#
+# This demo proves PR #179's fix to resource_keyfactor_security_identity.go:
+#
+#   resourceSecurityIdentity.Update() deliberately writes a concrete,
+#   non-null `roles` list into the result whenever config omits `roles`, to
+#   preserve the identity's existing role assignments across an unrelated
+#   Update. But `roles` was Optional and NOT Computed, so Terraform Core
+#   planned an omitted `roles` attribute as Null directly from config -- with
+#   no path for a provider-side plan modifier to intervene. Any identity
+#   with roles already assigned then crashed `terraform apply` with:
+#
+#     Provider produced inconsistent result after apply: .roles: was null,
+#     but now cty.ListVal(...)
+#
+# The fix marks `roles` Optional+Computed with a UseStateForUnknown plan
+# modifier, so an omitted `roles` attribute now resolves to "carry forward
+# the prior state value" instead of planning Null -- which, unlike the
+# sibling keyfactor_role/permissions fix, is ENOUGH on its own to trigger
+# the crash: the plan diff on `roles` alone (list -> null) is what causes
+# Terraform Core to call Update in the first place, no unrelated attribute
+# needs to change (keyfactor_identity has no other user-settable attribute
+# besides account_name, which is RequiresReplace).
+#
+# `make lab-omit-roles-update` (see GNUmakefile) applies this identity WITH
+# roles declared, then applies again with roles omitted from config
+# (roles_declared = false, which plans identically to a fully-absent
+# attribute at the protocol level) -- this must succeed without the
+# inconsistent-result crash, and the identity's role assignment must remain
+# present server-side afterward.
+#
+# IMPORTANT LAB CONSTRAINT: keyfactor_identity manages legacy Active
+# Directory identities only (see the resource's DeprecationMessage). The
+# default lab (int25-4-1.kftestlab.com, OAuth/EJBCA-backed, no AD) rejects
+# ANY account name here with HTTP 400 "Could not validate identity ... This
+# operation only supports Active Directory identities" -- confirmed
+# directly against POST /Security/Identities for KEYFACTOR\Administrator,
+# KFTESTLAB\Administrator, INT25-4-1\Administrator, and NT AUTHORITY\SYSTEM.
+# This is a hard, structural lab constraint (no AD backing exists to
+# validate against), not a provider defect: this resource cannot be created
+# against this lab regardless of provider code correctness. Point
+# account_name (via -var or KEYFACTOR_SECURITY_IDENTITY_NEW) at a real
+# AD-backed lab account not yet registered as a Keyfactor security identity
+# to exercise this demo end-to-end.
+# ---------------------------------------------------------------------------
+resource "keyfactor_identity" "demo" {
+  account_name = var.account_name
+  # An explicit HCL `null` and a fully-omitted attribute both decode to a
+  # null config value at the protocol level, so this ternary exercises the
+  # exact "omitted from config" code path without needing two separate .tf
+  # files for the two apply steps.
+  roles = var.roles_declared ? var.roles : null
+}
+
+output "identity_id" {
+  description = "ID of the created security identity."
+  value       = keyfactor_identity.demo.id
+}
+
+output "identity_account_name" {
+  description = "Account name of the created security identity."
+  value       = keyfactor_identity.demo.account_name
+}
+
+output "identity_roles" {
+  description = "Roles currently in Terraform state for the identity."
+  value       = keyfactor_identity.demo.roles
+}

--- a/terraform/security_identity_demo/variables.tf
+++ b/terraform/security_identity_demo/variables.tf
@@ -1,0 +1,23 @@
+variable "suffix" {
+  type        = string
+  default     = "_TF"
+  description = "Unused by this demo (keyfactor_identity has no user-settable name field besides account_name), declared only so the GNUmakefile can pass -var=\"suffix=...\" consistently with the other demos in this repo."
+}
+
+variable "account_name" {
+  type        = string
+  default     = "KEYFACTOR\\Administrator"
+  description = "AD account name (DOMAIN\\user, HCL-escaped as DOMAIN\\\\user) to register as a Keyfactor security identity. Must exist in Active Directory but not already be a Keyfactor security identity. Override with a real account from an AD-backed lab, e.g. via KEYFACTOR_SECURITY_IDENTITY_NEW-discovered value (see discoverCreatableIdentity in keyfactor/resource_keyfactor_security_identity_test.go)."
+}
+
+variable "roles_declared" {
+  type        = bool
+  default     = true
+  description = "Whether to declare the roles attribute in config. Set to false (via -var=\"roles_declared=false\") to omit roles from config entirely and prove PR179's fix preserves existing role assignments across an Update instead of crashing with 'Provider produced inconsistent result after apply'."
+}
+
+variable "roles" {
+  type        = list(string)
+  default     = ["Administrator"]
+  description = "Role names to assign when roles_declared is true."
+}

--- a/terraform/security_role_demo/GNUmakefile
+++ b/terraform/security_role_demo/GNUmakefile
@@ -1,0 +1,206 @@
+## security_role_demo/GNUmakefile
+##
+## Demonstrates end-to-end lifecycle of the legacy keyfactor_role
+## resource, and proves PR #178 (detect out-of-band drift on Read):
+##   build → init → validate → plan → apply → import → reconcile → drift-check → destroy
+##
+## The `lab-oob-drift` target is the actual regression proof for PR #178: it
+## mutates the role's permissions directly via the Command REST API (bypassing
+## Terraform), then asserts `terraform plan` reports drift instead of a false
+## "No changes."
+##
+## Usage:
+##   cd terraform/security_role_demo
+##   make build              # compile + install the provider locally
+##   make init               # terraform init
+##   make all                # run the full workflow
+##   make SUFFIX=_MYORG all  # run with a custom name suffix
+
+PROVIDER_ROOT  := $(abspath ../..)
+PROVIDER_BIN   := $(HOME)/go/bin
+SUFFIX         ?= _TF
+
+TF            := TF_CLI_CONFIG_FILE=.terraformrc terraform
+UNSET_BASIC   := unset KEYFACTOR_USERNAME KEYFACTOR_PASSWORD KEYFACTOR_DOMAIN;
+
+# ---------------------------------------------------------------------------
+# Lab environment helpers
+# Source LAB_ENV_FILE for OAuth credentials.
+# Override via: make LAB_ENV_FILE=~/.env_other lifecycle
+# ---------------------------------------------------------------------------
+SHELL         := /bin/bash
+LAB_ENV_FILE  ?= $(HOME)/.env_ses2541
+LAB_TIMEOUT   ?= 600
+
+LAB_ENV := set -a && source $(LAB_ENV_FILE) && set +a && \
+           unset KEYFACTOR_USERNAME KEYFACTOR_PASSWORD KEYFACTOR_DOMAIN && \
+           export KEYFACTOR_CLIENT_TIMEOUT=$(LAB_TIMEOUT) &&
+
+# ---------------------------------------------------------------------------
+# Provider build
+# ---------------------------------------------------------------------------
+
+## build: Compile and install the provider binary to ~/go/bin
+build:
+	@echo "==> Building provider..."
+	cd $(PROVIDER_ROOT) && go install .
+	@echo "==> Provider installed to $(PROVIDER_BIN)/terraform-provider-keyfactor"
+
+# ---------------------------------------------------------------------------
+# Terraform lifecycle
+# ---------------------------------------------------------------------------
+
+## init: Initialize the Terraform working directory
+init:
+	$(UNSET_BASIC) $(TF) init
+
+## validate: Validate the Terraform configuration
+validate:
+	$(UNSET_BASIC) $(TF) validate
+
+## plan: Show the execution plan
+plan:
+	$(UNSET_BASIC) $(TF) plan -var="suffix=$(SUFFIX)"
+
+## apply: Create the security role resource
+apply:
+	$(UNSET_BASIC) $(TF) apply -auto-approve -var="suffix=$(SUFFIX)"
+
+## import-all: Remove the managed resource from state then re-import by its real name
+import-all:
+	@echo "==> Capturing state..."
+	$(UNSET_BASIC) $(TF) show -json > tf_state.json
+	@echo "==> Extracting IDs from state..."
+	@ROLE_NAME=$$($(UNSET_BASIC) $(TF) output -raw role_name 2>/dev/null) && \
+	 ROLE_ID=$$($(UNSET_BASIC) $(TF) output -raw role_id 2>/dev/null) && \
+	 echo "Role Name=$$ROLE_NAME  Role ID=$$ROLE_ID" && \
+	 echo "==> Removing from state..." && \
+	 $(UNSET_BASIC) $(TF) state rm keyfactor_role.demo 2>&1 | grep -E "Removed|Successfully" || true && \
+	 echo "==> Re-importing by real name..." && \
+	 $(UNSET_BASIC) $(TF) import -var="suffix=$(SUFFIX)" keyfactor_role.demo "$$ROLE_NAME"
+
+## reconcile: Apply after import to reconcile fields not returned by the API
+reconcile:
+	$(UNSET_BASIC) $(TF) apply -auto-approve -var="suffix=$(SUFFIX)"
+
+## drift-check: Plan after reconcile — should show "No changes"
+drift-check:
+	$(UNSET_BASIC) $(TF) plan -var="suffix=$(SUFFIX)"
+
+## destroy: Destroy the managed security role resource
+destroy:
+	$(UNSET_BASIC) $(TF) destroy -auto-approve -var="suffix=$(SUFFIX)"
+
+## clean: Remove generated files
+clean:
+	rm -f tf_state.json terraform.tfstate terraform.tfstate.backup terraform.tfstate.*.backup
+
+# ---------------------------------------------------------------------------
+# Combined workflows
+# ---------------------------------------------------------------------------
+
+## all: Full workflow — build, init, validate, plan, apply, import-all, reconcile, drift-check, destroy
+all: build init validate plan apply import-all reconcile drift-check destroy
+
+## demo-no-destroy: Run workflow without final destroy (leaves resources on server)
+demo-no-destroy: build init validate plan apply import-all reconcile drift-check
+
+# ---------------------------------------------------------------------------
+# Lab convenience targets (source LAB_ENV_FILE automatically)
+# ---------------------------------------------------------------------------
+
+## lab-plan: Plan using lab credentials
+lab-plan:
+	$(LAB_ENV) $(MAKE) plan SUFFIX=$(SUFFIX)
+
+## lab-apply: Apply using lab credentials
+lab-apply:
+	$(LAB_ENV) $(MAKE) apply SUFFIX=$(SUFFIX)
+
+## lab-import-all: Import all resources using lab credentials
+lab-import-all:
+	$(LAB_ENV) $(MAKE) import-all SUFFIX=$(SUFFIX)
+
+## lab-reconcile: Reconcile after import
+lab-reconcile:
+	$(LAB_ENV) $(MAKE) reconcile SUFFIX=$(SUFFIX)
+
+## lab-drift-check: Drift-check using lab credentials
+lab-drift-check:
+	$(LAB_ENV) $(MAKE) drift-check SUFFIX=$(SUFFIX)
+
+## lab-destroy: Destroy all managed resources using lab credentials
+lab-destroy:
+	$(LAB_ENV) $(MAKE) destroy SUFFIX=$(SUFFIX)
+
+## lifecycle: Full lifecycle: apply → import-all → reconcile → drift-check → destroy
+lifecycle: lab-apply lab-import-all lab-reconcile lab-drift-check lab-destroy
+
+# ---------------------------------------------------------------------------
+# PR #178 regression proof — out-of-band drift detection
+#
+#   1. apply the Terraform-managed role
+#   2. mutate its permissions directly via the Command REST API
+#      (bypassing Terraform entirely)
+#   3. plan — MUST show drift (this is the PR178 fix); "No changes" here
+#      is a FAIL (that would mean the false-negative regressed)
+#   4. apply again to reconcile the role back to the Terraform-managed value
+#   5. plan again — MUST show "No changes"
+#
+# Uses `terraform plan -detailed-exitcode` for the assertion rather than
+# grepping text: exit 0 = no changes, exit 2 = changes present, exit 1 = error.
+# ---------------------------------------------------------------------------
+
+## lab-oob-drift: Regression proof for PR178 (detect out-of-band drift on Read)
+lab-oob-drift:
+	@echo "==> [1/5] apply Terraform-managed role..."
+	$(LAB_ENV) $(MAKE) apply SUFFIX=$(SUFFIX)
+	@echo "==> [2/5] mutate permissions out-of-band via direct Command API call..."
+	@$(LAB_ENV) \
+	 ROLE_ID=$$($(TF) output -raw role_id) && \
+	 ROLE_NAME=$$($(TF) output -raw role_name) && \
+	 echo "    target role: $$ROLE_NAME (id $$ROLE_ID)" && \
+	 TOKEN=$$(curl -sk -X POST "$$KEYFACTOR_AUTH_TOKEN_URL" \
+	   -d "grant_type=client_credentials&client_id=$$KEYFACTOR_AUTH_CLIENT_ID&client_secret=$$KEYFACTOR_AUTH_CLIENT_SECRET" \
+	   | jq -r '.access_token') && \
+	 HTTP_STATUS=$$(curl -sk -o /tmp/security_role_demo_oob_response.json -w "%{http_code}" -X PUT \
+	   "https://$$KEYFACTOR_HOSTNAME/$${KEYFACTOR_API_PATH:-Keyfactor/API}/Security/Roles" \
+	   -H "x-keyfactor-requested-with: APIClient" \
+	   -H "x-keyfactor-api-version: 1" \
+	   -H "Content-Type: application/json" \
+	   -H "Authorization: Bearer $$TOKEN" \
+	   -d "{\"Id\":$$ROLE_ID,\"Name\":\"$$ROLE_NAME\",\"Description\":\"Mutated out-of-band by lab-oob-drift ($(SUFFIX))\",\"Permissions\":[\"Certificates:Read\",\"Certificates:EditMetadata\"]}") && \
+	 echo "    PUT /Security/Roles HTTP status: $$HTTP_STATUS" && \
+	 cat /tmp/security_role_demo_oob_response.json && echo && \
+	 if [ "$$HTTP_STATUS" -lt 200 ] || [ "$$HTTP_STATUS" -ge 300 ]; then \
+	   echo "FAIL: out-of-band API mutation did not succeed (HTTP $$HTTP_STATUS)"; \
+	   exit 1; \
+	 fi
+	@echo "==> [3/5] plan — expect drift to be detected (PR178 regression proof)..."
+	@$(LAB_ENV) $(TF) plan -var="suffix=$(SUFFIX)" -detailed-exitcode -no-color > /tmp/security_role_demo_oob_plan.txt 2>&1; \
+	 PLAN_EXIT=$$?; \
+	 cat /tmp/security_role_demo_oob_plan.txt; \
+	 if [ $$PLAN_EXIT -eq 2 ]; then \
+	   echo "PASS: terraform plan detected the out-of-band drift (PR178 fix confirmed)."; \
+	 elif [ $$PLAN_EXIT -eq 0 ]; then \
+	   echo "FAIL: terraform plan reported \"No changes\" despite out-of-band mutation -- drift detection regressed."; \
+	   exit 1; \
+	 else \
+	   echo "FAIL: terraform plan errored (exit $$PLAN_EXIT)."; \
+	   exit 1; \
+	 fi
+	@echo "==> [4/5] reconcile -- apply to restore the Terraform-managed value..."
+	$(LAB_ENV) $(MAKE) apply SUFFIX=$(SUFFIX)
+	@echo "==> [5/5] final drift-check -- expect \"No changes\"..."
+	@$(LAB_ENV) $(TF) plan -var="suffix=$(SUFFIX)" -detailed-exitcode -no-color > /tmp/security_role_demo_oob_final_plan.txt 2>&1; \
+	 PLAN_EXIT=$$?; \
+	 cat /tmp/security_role_demo_oob_final_plan.txt; \
+	 if [ $$PLAN_EXIT -eq 0 ]; then \
+	   echo "PASS: final drift-check shows No changes -- reconciliation successful."; \
+	 else \
+	   echo "FAIL: final drift-check still shows drift (exit $$PLAN_EXIT)."; \
+	   exit 1; \
+	 fi
+
+.PHONY: build init validate plan apply import-all reconcile drift-check destroy clean all demo-no-destroy \
+        lab-plan lab-apply lab-import-all lab-reconcile lab-drift-check lab-destroy lifecycle lab-oob-drift

--- a/terraform/security_role_demo/main.tf
+++ b/terraform/security_role_demo/main.tf
@@ -1,0 +1,43 @@
+terraform {
+  required_providers {
+    keyfactor = {
+      source  = "keyfactor-pub/keyfactor"
+      version = ">= 2.0"
+    }
+  }
+}
+
+provider "keyfactor" {}
+
+# ---------------------------------------------------------------------------
+# Legacy (Active Directory / Version 1 permission model) security role.
+#
+# This demo exists to prove PR #178: resourceSecurityRole.Read previously
+# never called the Keyfactor Command API -- it just re-echoed whatever was
+# already in Terraform state, so out-of-band changes made directly against
+# Command (not through Terraform) were invisible to `terraform plan`. The
+# fix makes Read call GetSecurityRole and rebuild state from the live
+# server response.
+#
+# `make lab-oob-drift` (see GNUmakefile) applies this resource, then mutates
+# its permissions directly via a raw Command REST API call (bypassing
+# Terraform entirely), then asserts `terraform plan` reports drift instead
+# of "No changes" -- which is exactly the false negative this PR fixes.
+# ---------------------------------------------------------------------------
+resource "keyfactor_role" "demo" {
+  name        = "SecurityRoleDemo${var.suffix}"
+  description = var.role_description
+  permissions = [
+    "Certificates:Read",
+  ]
+}
+
+output "role_id" {
+  description = "ID of the created security role."
+  value       = keyfactor_role.demo.id
+}
+
+output "role_name" {
+  description = "Name of the created security role."
+  value       = keyfactor_role.demo.name
+}

--- a/terraform/security_role_demo/variables.tf
+++ b/terraform/security_role_demo/variables.tf
@@ -1,0 +1,11 @@
+variable "suffix" {
+  type        = string
+  default     = "_TF"
+  description = "Suffix appended to resource names to avoid conflicts."
+}
+
+variable "role_description" {
+  type        = string
+  default     = "Terraform-managed read-only certificate role (PR178 drift-detection demo)"
+  description = "Description for the security role."
+}

--- a/terraform/security_role_permissions_demo/GNUmakefile
+++ b/terraform/security_role_permissions_demo/GNUmakefile
@@ -1,0 +1,208 @@
+## security_role_permissions_demo/GNUmakefile
+##
+## Demonstrates end-to-end lifecycle of the legacy keyfactor_role resource,
+## and proves PR #179 (make `permissions` Optional+Computed to fix
+## "Provider produced inconsistent result after apply" when an unrelated
+## Update omits `permissions` from config):
+##   build → init → validate → plan → apply → import → reconcile → drift-check → destroy
+##
+## This is a SEPARATE demo from ../security_role_demo/ (left untouched --
+## that one proves the different PR #178 out-of-band drift-detection fix via
+## its `lab-oob-drift` target). Both fixes live in resource_keyfactor_security_role.go.
+##
+## The `lab-omit-permissions-update` target is the actual regression proof for
+## PR #179: it applies the role WITH permissions declared, then applies again
+## with `description` changed (an unrelated attribute) AND `permissions`
+## omitted from config entirely -- this must succeed without the
+## inconsistent-result crash, and the role's permissions must remain intact
+## server-side afterward.
+##
+## Usage:
+##   cd terraform/security_role_permissions_demo
+##   make build              # compile + install the provider locally
+##   make init               # terraform init
+##   make all                # run the full workflow
+##   make SUFFIX=_MYORG all  # run with a custom name suffix
+
+PROVIDER_ROOT  := $(abspath ../..)
+PROVIDER_BIN   := $(HOME)/go/bin
+SUFFIX         ?= _TF
+
+TF            := TF_CLI_CONFIG_FILE=.terraformrc terraform
+UNSET_BASIC   := unset KEYFACTOR_USERNAME KEYFACTOR_PASSWORD KEYFACTOR_DOMAIN;
+
+# ---------------------------------------------------------------------------
+# Lab environment helpers
+# Source LAB_ENV_FILE for OAuth credentials.
+# Override via: make LAB_ENV_FILE=~/.env_other lifecycle
+# ---------------------------------------------------------------------------
+SHELL         := /bin/bash
+LAB_ENV_FILE  ?= $(HOME)/.env_ses2541
+LAB_TIMEOUT   ?= 600
+
+LAB_ENV := set -a && source $(LAB_ENV_FILE) && set +a && \
+           unset KEYFACTOR_USERNAME KEYFACTOR_PASSWORD KEYFACTOR_DOMAIN && \
+           export KEYFACTOR_CLIENT_TIMEOUT=$(LAB_TIMEOUT) &&
+
+# ---------------------------------------------------------------------------
+# Provider build
+# ---------------------------------------------------------------------------
+
+## build: Compile and install the provider binary to ~/go/bin
+build:
+	@echo "==> Building provider..."
+	cd $(PROVIDER_ROOT) && go install .
+	@echo "==> Provider installed to $(PROVIDER_BIN)/terraform-provider-keyfactor"
+
+# ---------------------------------------------------------------------------
+# Terraform lifecycle
+# ---------------------------------------------------------------------------
+
+## init: Initialize the Terraform working directory
+init:
+	$(UNSET_BASIC) $(TF) init
+
+## validate: Validate the Terraform configuration
+validate:
+	$(UNSET_BASIC) $(TF) validate
+
+## plan: Show the execution plan
+plan:
+	$(UNSET_BASIC) $(TF) plan -var="suffix=$(SUFFIX)"
+
+## apply: Create the security role resource
+apply:
+	$(UNSET_BASIC) $(TF) apply -auto-approve -var="suffix=$(SUFFIX)"
+
+## import-all: Remove the managed resource from state then re-import by its real name
+import-all:
+	@echo "==> Capturing state..."
+	$(UNSET_BASIC) $(TF) show -json > tf_state.json
+	@echo "==> Extracting IDs from state..."
+	@ROLE_NAME=$$($(UNSET_BASIC) $(TF) output -raw role_name 2>/dev/null) && \
+	 ROLE_ID=$$($(UNSET_BASIC) $(TF) output -raw role_id 2>/dev/null) && \
+	 echo "Role Name=$$ROLE_NAME  Role ID=$$ROLE_ID" && \
+	 echo "==> Removing from state..." && \
+	 $(UNSET_BASIC) $(TF) state rm keyfactor_role.demo 2>&1 | grep -E "Removed|Successfully" || true && \
+	 echo "==> Re-importing by real name..." && \
+	 $(UNSET_BASIC) $(TF) import -var="suffix=$(SUFFIX)" keyfactor_role.demo "$$ROLE_NAME"
+
+## reconcile: Apply after import to reconcile fields not returned by the API
+reconcile:
+	$(UNSET_BASIC) $(TF) apply -auto-approve -var="suffix=$(SUFFIX)"
+
+## drift-check: Plan after reconcile — should show "No changes"
+drift-check:
+	$(UNSET_BASIC) $(TF) plan -var="suffix=$(SUFFIX)"
+
+## destroy: Destroy the managed security role resource
+destroy:
+	$(UNSET_BASIC) $(TF) destroy -auto-approve -var="suffix=$(SUFFIX)"
+
+## clean: Remove generated files
+clean:
+	rm -f tf_state.json terraform.tfstate terraform.tfstate.backup terraform.tfstate.*.backup
+
+# ---------------------------------------------------------------------------
+# Combined workflows
+# ---------------------------------------------------------------------------
+
+## all: Full workflow — build, init, validate, plan, apply, import-all, reconcile, drift-check, destroy
+all: build init validate plan apply import-all reconcile drift-check destroy
+
+## demo-no-destroy: Run workflow without final destroy (leaves resources on server)
+demo-no-destroy: build init validate plan apply import-all reconcile drift-check
+
+# ---------------------------------------------------------------------------
+# Lab convenience targets (source LAB_ENV_FILE automatically)
+# ---------------------------------------------------------------------------
+
+## lab-plan: Plan using lab credentials
+lab-plan:
+	$(LAB_ENV) $(MAKE) plan SUFFIX=$(SUFFIX)
+
+## lab-apply: Apply using lab credentials
+lab-apply:
+	$(LAB_ENV) $(MAKE) apply SUFFIX=$(SUFFIX)
+
+## lab-import-all: Import all resources using lab credentials
+lab-import-all:
+	$(LAB_ENV) $(MAKE) import-all SUFFIX=$(SUFFIX)
+
+## lab-reconcile: Reconcile after import
+lab-reconcile:
+	$(LAB_ENV) $(MAKE) reconcile SUFFIX=$(SUFFIX)
+
+## lab-drift-check: Drift-check using lab credentials
+lab-drift-check:
+	$(LAB_ENV) $(MAKE) drift-check SUFFIX=$(SUFFIX)
+
+## lab-destroy: Destroy all managed resources using lab credentials
+lab-destroy:
+	$(LAB_ENV) $(MAKE) destroy SUFFIX=$(SUFFIX)
+
+## lifecycle: Full lifecycle: apply → import-all → reconcile → drift-check → destroy
+lifecycle: lab-apply lab-import-all lab-reconcile lab-drift-check lab-destroy
+
+# ---------------------------------------------------------------------------
+# PR #179 regression proof — permissions omitted on an unrelated Update
+#
+#   1. apply with permissions declared (permissions_declared=true) and an
+#      initial description
+#   2. apply again with description CHANGED (the unrelated attribute) AND
+#      permissions omitted from config (permissions_declared=false) --
+#      pre-fix this crashed terraform apply with "Provider produced
+#      inconsistent result after apply: .permissions: was null, but now
+#      cty.ListVal(...)"; post-fix this must succeed cleanly
+#   3. verify via a direct Command REST API call that the role's permissions
+#      are still intact server-side (preserved, not cleared)
+#   4. destroy
+# ---------------------------------------------------------------------------
+
+## lab-omit-permissions-update: Regression proof for PR179 (permissions Optional+Computed fix)
+lab-omit-permissions-update:
+	@echo "==> [1/4] apply WITH permissions declared..."
+	$(LAB_ENV) $(TF) apply -auto-approve \
+	  -var="suffix=$(SUFFIX)" \
+	  -var="role_description=Initial description (PR179 demo)" \
+	  -var="permissions_declared=true"
+	@echo "==> [2/4] apply again: description changed (unrelated attribute), permissions OMITTED from config..."
+	@$(LAB_ENV) $(TF) apply -auto-approve -no-color \
+	  -var="suffix=$(SUFFIX)" \
+	  -var="role_description=Updated description -- unrelated Update (PR179 demo)" \
+	  -var="permissions_declared=false" > /tmp/security_role_permissions_demo_apply2.txt 2>&1; \
+	 APPLY_EXIT=$$?; \
+	 cat /tmp/security_role_permissions_demo_apply2.txt; \
+	 if [ $$APPLY_EXIT -eq 0 ]; then \
+	   echo "PASS: apply succeeded with permissions omitted on an unrelated Update (PR179 fix confirmed)."; \
+	 else \
+	   echo "FAIL: apply failed (exit $$APPLY_EXIT) -- inconsistent-result-after-apply regression."; \
+	   exit 1; \
+	 fi
+	@echo "==> [3/4] verify permissions are still intact server-side (direct Command API call)..."
+	@$(LAB_ENV) \
+	 ROLE_ID=$$($(TF) output -raw role_id) && \
+	 ROLE_NAME=$$($(TF) output -raw role_name) && \
+	 echo "    target role: $$ROLE_NAME (id $$ROLE_ID)" && \
+	 TOKEN=$$(curl -sk -X POST "$$KEYFACTOR_AUTH_TOKEN_URL" \
+	   -d "grant_type=client_credentials&client_id=$$KEYFACTOR_AUTH_CLIENT_ID&client_secret=$$KEYFACTOR_AUTH_CLIENT_SECRET" \
+	   | jq -r '.access_token') && \
+	 curl -sk "https://$$KEYFACTOR_HOSTNAME/$${KEYFACTOR_API_PATH:-Keyfactor/API}/Security/Roles/$$ROLE_ID" \
+	   -H "x-keyfactor-requested-with: APIClient" \
+	   -H "x-keyfactor-api-version: 1" \
+	   -H "Authorization: Bearer $$TOKEN" > /tmp/security_role_permissions_demo_verify.json && \
+	 cat /tmp/security_role_permissions_demo_verify.json | jq . && \
+	 if jq -e '.Permissions | index("Certificates:Read")' /tmp/security_role_permissions_demo_verify.json > /dev/null; then \
+	   echo "PASS: server-side permissions still contain Certificates:Read -- preserved, not cleared."; \
+	 else \
+	   echo "FAIL: server-side permissions no longer contain Certificates:Read -- permissions were cleared."; \
+	   exit 1; \
+	 fi
+	@echo "==> [4/4] destroy..."
+	$(LAB_ENV) $(TF) destroy -auto-approve \
+	  -var="suffix=$(SUFFIX)" \
+	  -var="role_description=Updated description -- unrelated Update (PR179 demo)" \
+	  -var="permissions_declared=false"
+
+.PHONY: build init validate plan apply import-all reconcile drift-check destroy clean all demo-no-destroy \
+        lab-plan lab-apply lab-import-all lab-reconcile lab-drift-check lab-destroy lifecycle lab-omit-permissions-update

--- a/terraform/security_role_permissions_demo/main.tf
+++ b/terraform/security_role_permissions_demo/main.tf
@@ -1,0 +1,70 @@
+terraform {
+  required_providers {
+    keyfactor = {
+      source  = "keyfactor-pub/keyfactor"
+      version = ">= 2.0"
+    }
+  }
+}
+
+provider "keyfactor" {}
+
+# ---------------------------------------------------------------------------
+# Legacy (Active Directory / Version 1 permission model) security role.
+#
+# This demo is a SEPARATE, purpose-built proof from terraform/security_role_demo/
+# (left untouched -- that demo already proves PR #178's out-of-band drift-detection
+# fix via its `lab-oob-drift` target). This demo proves the DIFFERENT PR #179 fix:
+#
+#   resourceSecurityRole.Update() deliberately writes a concrete, non-null
+#   `permissions` list into the result whenever config omits `permissions`, to
+#   preserve the role's existing permissions across an unrelated Update (e.g.
+#   changing only `description`). But `permissions` was Optional and NOT
+#   Computed, so Terraform Core planned an omitted `permissions` attribute as
+#   Null directly from config -- with no path for a provider-side plan
+#   modifier to intervene. Any role with permissions already assigned then
+#   crashed `terraform apply` on any unrelated Update with:
+#
+#     Provider produced inconsistent result after apply: .permissions: was
+#     null, but now cty.ListVal(...)
+#
+# The fix marks `permissions` Optional+Computed with a UseStateForUnknown
+# plan modifier, so Terraform Core now resolves an omitted `permissions`
+# attribute to "carry forward the prior state value" instead of planning
+# Null, and the Update logic keys off request.Config (never touched by plan
+# modifiers) rather than request.Plan to correctly distinguish "omitted"
+# from "explicitly re-declared."
+#
+# `make lab-omit-permissions-update` (see GNUmakefile) is the regression
+# proof: it applies this role WITH permissions declared, then applies again
+# with `description` changed (the unrelated attribute) AND `permissions`
+# omitted from config entirely (permissions_declared = false, which plans
+# identically to omitting the attribute -- an explicit HCL `null` and a
+# fully-absent attribute both decode to a null config value at the
+# protocol level). This must succeed without the inconsistent-result crash,
+# and the role's permissions must remain intact server-side afterward.
+# ---------------------------------------------------------------------------
+resource "keyfactor_role" "demo" {
+  name        = "SecurityRolePermsDemo${var.suffix}"
+  description = var.role_description
+  # An explicit HCL `null` and a fully-omitted attribute both decode to a
+  # null config value at the protocol level, so this ternary exercises the
+  # exact "omitted from config" code path without needing two separate .tf
+  # files for the two apply steps.
+  permissions = var.permissions_declared ? var.permissions : null
+}
+
+output "role_id" {
+  description = "ID of the created security role."
+  value       = keyfactor_role.demo.id
+}
+
+output "role_name" {
+  description = "Name of the created security role."
+  value       = keyfactor_role.demo.name
+}
+
+output "role_permissions" {
+  description = "Permissions currently in Terraform state for the role."
+  value       = keyfactor_role.demo.permissions
+}

--- a/terraform/security_role_permissions_demo/variables.tf
+++ b/terraform/security_role_permissions_demo/variables.tf
@@ -1,0 +1,23 @@
+variable "suffix" {
+  type        = string
+  default     = "_TF"
+  description = "Suffix appended to resource names to avoid conflicts."
+}
+
+variable "role_description" {
+  type        = string
+  default     = "Terraform-managed role (PR179 permissions-omission-on-update demo)"
+  description = "Description for the security role. Changed between apply steps to exercise an unrelated-attribute Update while permissions is omitted."
+}
+
+variable "permissions_declared" {
+  type        = bool
+  default     = true
+  description = "Whether to declare the permissions attribute in config. Set to false to omit permissions from config entirely (proves PR179's fix preserves existing permissions across an unrelated Update instead of crashing with 'Provider produced inconsistent result after apply')."
+}
+
+variable "permissions" {
+  type        = list(string)
+  default     = ["Certificates:Read"]
+  description = "Permissions to assign when permissions_declared is true."
+}

--- a/terraform/template_role_binding_demo/GNUmakefile
+++ b/terraform/template_role_binding_demo/GNUmakefile
@@ -1,0 +1,132 @@
+## template_role_binding_demo/GNUmakefile
+##
+## Full-lifecycle smoke test for keyfactor_template_role_binding, covering
+## PR #179's fix to Read()'s swallowed GetTemplates() API error:
+##   build → init → validate → plan → apply → import → reconcile → drift-check → destroy
+##
+## Usage:
+##   cd terraform/template_role_binding_demo
+##   make build
+##   make init
+##   make lifecycle
+##   make SUFFIX=_MYORG lifecycle
+
+PROVIDER_ROOT  := $(abspath ../..)
+PROVIDER_BIN   := $(HOME)/go/bin
+SUFFIX         ?= _TF
+
+TF            := TF_CLI_CONFIG_FILE=.terraformrc terraform
+UNSET_BASIC   := unset KEYFACTOR_USERNAME KEYFACTOR_PASSWORD KEYFACTOR_DOMAIN;
+
+# ---------------------------------------------------------------------------
+# Lab environment helpers
+# ---------------------------------------------------------------------------
+SHELL         := /bin/bash
+LAB_ENV_FILE  ?= $(HOME)/.env_ses2541
+LAB_TIMEOUT   ?= 600
+
+LAB_ENV := set -a && source $(LAB_ENV_FILE) && set +a && \
+           unset KEYFACTOR_USERNAME KEYFACTOR_PASSWORD KEYFACTOR_DOMAIN && \
+           export KEYFACTOR_CLIENT_TIMEOUT=$(LAB_TIMEOUT) &&
+
+# ---------------------------------------------------------------------------
+# Provider build
+# ---------------------------------------------------------------------------
+
+## build: Compile and install the provider binary to ~/go/bin
+build:
+	@echo "==> Building provider..."
+	cd $(PROVIDER_ROOT) && go install .
+	@echo "==> Provider installed to $(PROVIDER_BIN)/terraform-provider-keyfactor"
+
+# ---------------------------------------------------------------------------
+# Terraform lifecycle
+# ---------------------------------------------------------------------------
+
+## init: Initialize the Terraform working directory
+init:
+	$(UNSET_BASIC) $(TF) init
+
+## validate: Validate the Terraform configuration
+validate:
+	$(UNSET_BASIC) $(TF) validate
+
+## plan: Show the execution plan
+plan:
+	$(UNSET_BASIC) $(TF) plan -var="suffix=$(SUFFIX)"
+
+## apply: Create the role and template role binding
+apply:
+	$(UNSET_BASIC) $(TF) apply -auto-approve -var="suffix=$(SUFFIX)"
+
+## import-all: Remove both managed resources from state then re-import by role name
+import-all:
+	@echo "==> Capturing state..."
+	$(UNSET_BASIC) $(TF) show -json > tf_state.json
+	@echo "==> Extracting role name from state..."
+	@ROLE_NAME=$$($(UNSET_BASIC) $(TF) output -raw role_name 2>/dev/null) && \
+	 echo "Role Name=$$ROLE_NAME" && \
+	 echo "==> Removing from state..." && \
+	 $(UNSET_BASIC) $(TF) state rm keyfactor_template_role_binding.demo 2>&1 | grep -E "Removed|Successfully" || true && \
+	 $(UNSET_BASIC) $(TF) state rm keyfactor_role.demo 2>&1 | grep -E "Removed|Successfully" || true && \
+	 echo "==> Re-importing keyfactor_role by name..." && \
+	 $(UNSET_BASIC) $(TF) import -var="suffix=$(SUFFIX)" keyfactor_role.demo "$$ROLE_NAME" && \
+	 echo "==> Re-importing keyfactor_template_role_binding by role name..." && \
+	 $(UNSET_BASIC) $(TF) import -var="suffix=$(SUFFIX)" keyfactor_template_role_binding.demo "$$ROLE_NAME"
+
+## reconcile: Apply after import to reconcile fields not returned by the API
+reconcile:
+	$(UNSET_BASIC) $(TF) apply -auto-approve -var="suffix=$(SUFFIX)"
+
+## drift-check: Plan after reconcile — should show "No changes"
+drift-check:
+	$(UNSET_BASIC) $(TF) plan -var="suffix=$(SUFFIX)"
+
+## destroy: Destroy the managed resources
+destroy:
+	$(UNSET_BASIC) $(TF) destroy -auto-approve -var="suffix=$(SUFFIX)"
+
+## clean: Remove generated files
+clean:
+	rm -f tf_state.json terraform.tfstate terraform.tfstate.backup terraform.tfstate.*.backup
+
+# ---------------------------------------------------------------------------
+# Combined workflows
+# ---------------------------------------------------------------------------
+
+## all: Full workflow — build, init, validate, plan, apply, import-all, reconcile, drift-check, destroy
+all: build init validate plan apply import-all reconcile drift-check destroy
+
+# ---------------------------------------------------------------------------
+# Lab convenience targets (source LAB_ENV_FILE automatically)
+# ---------------------------------------------------------------------------
+
+## lab-plan: Plan using lab credentials
+lab-plan:
+	$(LAB_ENV) $(MAKE) plan SUFFIX=$(SUFFIX)
+
+## lab-apply: Apply using lab credentials
+lab-apply:
+	$(LAB_ENV) $(MAKE) apply SUFFIX=$(SUFFIX)
+
+## lab-import-all: Import all resources using lab credentials
+lab-import-all:
+	$(LAB_ENV) $(MAKE) import-all SUFFIX=$(SUFFIX)
+
+## lab-reconcile: Reconcile after import
+lab-reconcile:
+	$(LAB_ENV) $(MAKE) reconcile SUFFIX=$(SUFFIX)
+
+## lab-drift-check: Drift-check using lab credentials
+lab-drift-check:
+	$(LAB_ENV) $(MAKE) drift-check SUFFIX=$(SUFFIX)
+
+## lab-destroy: Destroy all managed resources using lab credentials
+lab-destroy:
+	$(LAB_ENV) $(MAKE) destroy SUFFIX=$(SUFFIX)
+
+## lifecycle: Full lifecycle: apply → import-all → reconcile → drift-check → destroy
+lifecycle: lab-apply lab-import-all lab-reconcile lab-drift-check lab-destroy
+
+.PHONY: build init validate plan apply import-all reconcile drift-check destroy clean all \
+        lab-plan lab-apply lab-import-all lab-reconcile lab-drift-check lab-destroy lifecycle

--- a/terraform/template_role_binding_demo/main.tf
+++ b/terraform/template_role_binding_demo/main.tf
@@ -1,0 +1,71 @@
+terraform {
+  required_providers {
+    keyfactor = {
+      source  = "keyfactor-pub/keyfactor"
+      version = ">= 2.0"
+    }
+  }
+}
+
+provider "keyfactor" {}
+
+# ---------------------------------------------------------------------------
+# keyfactor_template_role_binding full-lifecycle smoke test.
+#
+# Proves PR #179's fix to resource_keyfactor_template_role_binding.go: Read()
+# silently swallowed a GetTemplates() API error (no diagnostic, no early
+# return), unlike Create()'s identical call which already handled it
+# correctly. Read() now mirrors Create()'s AddError + return handling.
+#
+# This demo attaches a purpose-built role to var.template_short_name (an
+# EXISTING template already using UseAllowedRequesters -- see the lab
+# discovery below) and verifies via `terraform plan` after apply/import that
+# only the added role shows up, and the template's pre-existing
+# AllowedRequesters entries are left alone. That "don't touch unrelated
+# requesters" behavior is a different, already-covered fix in this same
+# file; this demo's real purpose is exercising the ordinary Read() happy
+# path end-to-end via the real terraform CLI, as a regression guard for the
+# swallowed-error fix (a full lifecycle can't easily force GetTemplates() to
+# fail, but it proves the ordinary non-error Read() path -- exercised on
+# every plan/refresh in this demo -- still works correctly after the fix).
+#
+# KNOWN BLOCKER (discovered validating this demo against
+# int25-4-1.kftestlab.com, unrelated to PR #179): `apply` currently fails on
+# EVERY template in this lab (checked all 5 via `make api-list-templates`)
+# with "Error updating template in Keyfactor: 'Policies' cannot be empty".
+# keyfactor-go-client/v3's UpdateTemplateArg (template_models.go) has no
+# `Policies` field at all, and buildTemplateRoleBindingUpdateArg in
+# resource_keyfactor_template_role_binding.go never sets one -- this looks
+# like a genuine, separate SDK/Command-API-version gap (Command now requires
+# a field the SDK's request model doesn't model), not something introduced
+# or touched by PR #179. Attach/detach against this lab is blocked until
+# that's fixed; this demo's `apply` step will fail until then. Filed as a
+# follow-up, not fixed here -- out of scope for PR #179's Read()-only fix.
+# ---------------------------------------------------------------------------
+resource "keyfactor_role" "demo" {
+  name        = "TemplateRoleBindingDemo${var.suffix}"
+  description = "Terraform-managed role (PR179 template_role_binding demo)"
+  permissions = []
+}
+
+resource "keyfactor_template_role_binding" "demo" {
+  role_name             = keyfactor_role.demo.name
+  template_short_names  = [var.template_short_name]
+
+  depends_on = [keyfactor_role.demo]
+}
+
+output "role_name" {
+  description = "Name of the created security role."
+  value       = keyfactor_role.demo.name
+}
+
+output "binding_id" {
+  description = "ID of the template role binding."
+  value       = keyfactor_template_role_binding.demo.id
+}
+
+output "template_short_names" {
+  description = "Template short names currently bound to the role in Terraform state."
+  value       = keyfactor_template_role_binding.demo.template_short_names
+}

--- a/terraform/template_role_binding_demo/variables.tf
+++ b/terraform/template_role_binding_demo/variables.tf
@@ -1,0 +1,11 @@
+variable "suffix" {
+  type        = string
+  default     = "_TF"
+  description = "Suffix appended to resource names to avoid conflicts."
+}
+
+variable "template_short_name" {
+  type        = string
+  default     = "Server_tlsServerAuth-1y"
+  description = "An existing certificate template short name with UseAllowedRequesters already enabled, to bind the demo role to. Discovered via `make api-list-templates` against int25-4-1.kftestlab.com; override for other labs."
+}


### PR DESCRIPTION
## Summary

Triages 7 independently-verified findings from a high-effort code review of PR #177's diff (base `fix/template-role-binding-pagination`, head `fix/inconsistent-state-audit-triage`, 31 commits) — 4 correctness bugs and 3 cleanup items — plus one additional correctness bug found while validating the fix against a live lab, and real-`terraform`-CLI regression coverage for both.

### Commits, in landing order

**Correctness (5):**
- `fix(security-identity)` — `roles` made Optional+Computed with `UseStateForUnknown`; `Update()` now reads `request.Config` (not `request.Plan`) to distinguish "declared" from "omitted." Fixes a real "Provider produced inconsistent result after apply" crash: `Update()` was writing a concrete `Roles` list into state whenever the plan was Null, but the attribute wasn't `Computed`, so Terraform Core rejected the apply on any identity with existing roles and an unrelated Update omitting `roles` from config.
- `fix(security-role)` — identical defect and fix shape for `permissions`.
- `fix(template-role-binding)` — `Read()`'s swallowed `GetTemplates()` API error now mirrors `Create()`'s `AddError` + return handling, instead of silently reporting "no drift" on a failed refresh.
- `fix(helpers)` — `mapOAuthSecurityClaimsFromRole` now warns instead of silently substituting an empty `ProviderAuthenticationScheme` when a claim's `Provider` is nil, closing a path that could corrupt a claim's provider association on an unrelated security-role Update.
- `fix(security-role)` — **found by recording a VCR cassette against a live lab rather than hand-authoring one**: the `permissions` Optional+Computed fix above assumed omitting the `Permissions` field from the PUT body would make Command preserve a role's existing permissions. That assumption was never verified against a live server and was wrong — Command's `PUT /Security/Roles` is a full-replace endpoint; omitting `Permissions` clears it (`"Permissions":[]` came back in the recorded response). `buildSecurityRoleUpdateArg` now explicitly resends `state.Permissions` when the config value is undeclared, instead of omitting the field. The hand-authored mock server backing the original fix's regression test couldn't have caught this — it echoed a canned response regardless of what was actually sent.

**Cleanup (3):**
- `refactor(certificate-authority,pam-provider-type)` — extracted a generic `enumPtrToTfInt64[T ~int32]` helper, replacing 4 near-identical converters.
- `refactor(oauth-role-claim,helpers)` — replaced the `getStringType(...).Value` idiom (7 call sites) with a plain `derefOrEmpty` helper.
- `test` — extracted a shared `mockAuthConfig` test helper, replacing 3 duplicated `httptest` mock structs.

**Test infrastructure:**
- `test(demo)` — adds `terraform/security_identity_demo/` and `terraform/security_role_permissions_demo/` (plus `terraform/security_role_demo/`, documenting the separate already-merged PR #178 fix), real Terraform-CLI lab lifecycle demos following the existing `terraform/oauth_security_demo/` convention. `make security-role-permissions-demo-omit-update` and `make security-identity-demo-omit-update` are the actual regression proofs: apply with the attribute declared, apply again with it omitted from config (plus, for the role demo, an unrelated `description` change), and — for the role demo — cross-check via a direct Command REST call that the value is still intact server-side.

Rebased onto `fix/inconsistent-state-audit-triage` after PR #178 (the `security_role` Read-drift-detection fix) merged into it — that fix and this one both touch `resource_keyfactor_security_role.go`; the rebase conflict (in the unit test file only, both sides purely additive) was resolved by keeping all tests from both.

## Test plan

- [x] Every commit has its own red→green regression test where the harness can catch the defect
- [x] `go build ./...` clean throughout
- [x] `make testunit` green: 154 pass, 0 fail, 3 pre-existing/unrelated skips
- [x] Vendor-free validation (`rm -rf vendor && GOWORK=off go test -mod=mod ./keyfactor/... -run TestUnit`) — identical pass count
- [x] Re-verified after rebasing onto PR #178's merge commit: `go build ./...` clean, `make testunit` green (0 failures)
- [x] **Real `terraform` CLI validation against the live lab** (`int25-4-1.kftestlab.com`), not just Go-level `resource.UnitTest`: built the provider from this branch, ran `make security-role-permissions-demo-omit-update` end-to-end —
  1. `terraform apply` with `permissions = ["Certificates:Read"]` declared
  2. `terraform apply` again with `description` changed and `permissions` omitted entirely from config — clean plan (`permissions` doesn't even appear in the diff), no inconsistent-result crash
  3. direct Command REST call confirmed `Permissions: ["Certificates:Read"]` still present server-side afterward
  4. `terraform destroy` cleaned up

  This run is what caught the follow-up `buildSecurityRoleUpdateArg` bug above in the first place (the initial VCR recording attempt failed with `.permissions: element 0 has vanished`, since Command really does clear omitted `Permissions` on PUT).
