### PR TITLE
fix(certificate): use plan values for friendly_name/use_cn_as_friendly_name

### DIFF
--- a/keyfactor/resource_keyfactor_certificate.go
+++ b/keyfactor/resource_keyfactor_certificate.go
@@ -1745,10 +1745,16 @@ func (r resourceCommandCertificate) Update(
 			CertificateAuthority: knownStringFromPlan(plan.CertificateAuthority),
 			CertificateTemplate:  plan.CertificateTemplate,
 			Metadata:             knownMetadataFromPlan(plan.Metadata),
-			UseCNAsFriendlyName:  state.UseCNAsFriendlyName,
-			FriendlyName:         state.FriendlyName,
-			CollectionId:         plan.CollectionId,
-			ExpiryWarningDays:    plan.ExpiryWarningDays,
+			// friendly_name/use_cn_as_friendly_name are plain Optional (not Computed)
+			// attributes: Terraform's plan has already resolved their final value from
+			// config before Update ever runs, so the provider has no discretion here.
+			// Using state.X served the OLD value whenever config changed or removed
+			// these fields, disagreeing with Terraform's own plan and producing
+			// "provider produced inconsistent result after apply".
+			UseCNAsFriendlyName: plan.UseCNAsFriendlyName,
+			FriendlyName:        plan.FriendlyName,
+			CollectionId:        plan.CollectionId,
+			ExpiryWarningDays:   plan.ExpiryWarningDays,
 			IsExpired: types.Bool{
 				Value: expired,
 			},
@@ -1864,10 +1870,16 @@ func (r resourceCommandCertificate) Update(
 			CertificateAuthority: state.CertificateAuthority,
 			CertificateTemplate:  plan.CertificateTemplate,
 			Metadata:             knownMetadataFromPlan(plan.Metadata),
-			UseCNAsFriendlyName:  state.UseCNAsFriendlyName,
-			FriendlyName:         state.FriendlyName,
-			CollectionId:         plan.CollectionId,
-			ExpiryWarningDays:    plan.ExpiryWarningDays,
+			// friendly_name/use_cn_as_friendly_name are plain Optional (not Computed)
+			// attributes: Terraform's plan has already resolved their final value from
+			// config before Update ever runs, so the provider has no discretion here.
+			// Using state.X served the OLD value whenever config changed or removed
+			// these fields, disagreeing with Terraform's own plan and producing
+			// "provider produced inconsistent result after apply".
+			UseCNAsFriendlyName: plan.UseCNAsFriendlyName,
+			FriendlyName:        plan.FriendlyName,
+			CollectionId:        plan.CollectionId,
+			ExpiryWarningDays:   plan.ExpiryWarningDays,
 			IsExpired: types.Bool{
 				Value: expired,
 			},
@@ -2341,9 +2353,16 @@ func (r resourceCommandCertificate) ImportState(
 		CertificateTemplate: types.String{Value: templateName, Null: isNullString(templateName)},
 		Metadata:            metadata,
 		CertificateId:       types.Int64{Value: int64(certificateIdInt), Null: isNullId(certificateIdInt)},
-		CollectionId:        state.CollectionId,
-		FriendlyName:        state.FriendlyName,
-		UseCNAsFriendlyName: state.UseCNAsFriendlyName,
+		// collection_id, friendly_name, and use_cn_as_friendly_name have no
+		// server-side recoverable value during import (state is always a fresh
+		// zero-valued struct here, not a prior import). Setting them from state.X
+		// would produce a KNOWN zero value (0/""/false) rather than an explicit
+		// null, which disagrees with the null Update() writes for these attributes
+		// once config doesn't set them -- causing "provider produced inconsistent
+		// result after apply" on the very first reconcile apply after import.
+		CollectionId:        types.Int64{Null: true},
+		FriendlyName:        types.String{Null: true},
+		UseCNAsFriendlyName: types.Bool{Null: true},
 		RequestId:           types.Int64{Value: int64(requestId), Null: isNullId(requestId)},
 		ExpiryWarningDays:   types.Int64{Null: true},  // write-only; isNullId(0)==true means not set
 		IsExpired:           types.Bool{Value: false}, // Set to false as we just enrolled the certificate

--- a/keyfactor/resource_keyfactor_certificate_friendlyname_unit_test.go
+++ b/keyfactor/resource_keyfactor_certificate_friendlyname_unit_test.go
@@ -1,0 +1,306 @@
+package keyfactor
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	api "github.com/Keyfactor/keyfactor-go-client/v3/api"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// ---------------------------------------------------------------------------
+// Regression tests for a "provider produced inconsistent result after apply"
+// bug found and confirmed against a live Keyfactor Command lab: Update()
+// hardcoded state.FriendlyName/state.UseCNAsFriendlyName into its result
+// struct instead of plan.FriendlyName/plan.UseCNAsFriendlyName, even though
+// friendly_name and use_cn_as_friendly_name are plain Optional (not Computed)
+// schema attributes whose final value Terraform's plan step has already
+// resolved from config before Update ever runs. Separately, ImportState set
+// these two fields (plus collection_id) from a freshly zero-valued `state`
+// struct -- a KNOWN Go zero value (empty string / false), not an explicit
+// null -- which disagreed with the null Update() writes once config doesn't
+// set these fields, causing a same-apply crash on the very first reconcile
+// apply immediately after `terraform import`.
+// ---------------------------------------------------------------------------
+
+// buildFriendlyNameTestLeaf creates a small self-signed leaf certificate for
+// driving Update()/ImportState() through their real GetCertificateContext /
+// DownloadCertificate code paths without touching a live Command instance.
+func buildFriendlyNameTestLeaf(t *testing.T, cn string) *x509.Certificate {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
+		IsCA:                  false,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse cert: %v", err)
+	}
+	return leaf
+}
+
+// newFriendlyNameMockClient wires an api.Client to srv, mirroring the
+// pattern used by the sibling Update/ImportState unit tests in this package
+// (resource_keyfactor_certificate_unit_test.go,
+// resource_keyfactor_certificate_import_sans_unit_test.go).
+func newFriendlyNameMockClient(srv *httptest.Server) *api.Client {
+	return &api.Client{
+		AuthClient: &certUpdateMockAuthConfig{server: srv},
+	}
+}
+
+// TestUnitKeyfactorCertificateResource_Update_FriendlyNameFollowsPlan drives
+// resourceCommandCertificate.Update directly against a mock Command server
+// and asserts that the resulting state's friendly_name/use_cn_as_friendly_name
+// match the PLAN values, not the prior STATE values, in both the non-CSR and
+// CSR branches of Update.
+//
+// Red/green proof: on the unfixed code, Update's result struct literals read
+// `state.FriendlyName`/`state.UseCNAsFriendlyName` -- this test fails because
+// the returned state still has the OLD ("state-old-friendly"/false) values
+// even though the plan declared new ones. After the fix (plan.FriendlyName/
+// plan.UseCNAsFriendlyName), the test passes.
+func TestUnitKeyfactorCertificateResource_Update_FriendlyNameFollowsPlan(t *testing.T) {
+	cases := []struct {
+		name string
+		csr  bool // true drives the CSR branch of Update, false the non-CSR branch
+	}{
+		{name: "non_csr_branch", csr: false},
+		{name: "csr_branch", csr: true},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			const certID = 845090
+			const cn = "tf-unit-friendlyname-update.example.com"
+			leaf := buildFriendlyNameTestLeaf(t, cn)
+
+			certGetResp := api.GetCertificateResponse{
+				Id:              certID,
+				IssuedCN:        cn,
+				ContentBytes:    base64.StdEncoding.EncodeToString(leaf.Raw),
+				HasPrivateKey:   false,
+				CertStateString: "Unknown",
+			}
+			getBody, err := json.Marshal(certGetResp)
+			if err != nil {
+				t.Fatalf("marshal certGetResp: %v", err)
+			}
+
+			mux := http.NewServeMux()
+			mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(getBody)
+			})
+			server := httptest.NewTLSServer(mux)
+			defer server.Close()
+
+			client := newFriendlyNameMockClient(server)
+
+			schema, sDiags := resourceCommandCertificateType{}.GetSchema(context.Background())
+			if sDiags.HasError() {
+				t.Fatalf("GetSchema returned diagnostics: %+v", sDiags)
+			}
+
+			nullList := types.List{ElemType: types.StringType, Null: true}
+			nullMap := types.Map{ElemType: types.StringType, Null: true}
+
+			plan := CommandCertificate{
+				ID:                   types.String{Value: "845090"},
+				CertificateId:        types.Int64{Value: certID},
+				CollectionId:         types.Int64{Value: 0},
+				ExpiryWarningDays:    types.Int64{Null: true},
+				DNSSANs:              nullList,
+				IPSANs:               nullList,
+				URISANs:              nullList,
+				Metadata:             nullMap,
+				CertificateAuthority: types.String{Null: true},
+				CertificateTemplate:  types.String{Null: true},
+				EnrollmentPattern:    types.String{Null: true},
+				OwnerRoleName:        types.String{Null: true},
+				CertificateFormat:    types.String{Null: true},
+				RevokeOnDestroy:      types.Bool{Null: true},
+				KeyPassword:          types.String{Null: true},
+				// The values under test: the plan is what Terraform has
+				// already resolved from config for this apply.
+				FriendlyName:        types.String{Value: "plan-friendly"},
+				UseCNAsFriendlyName: types.Bool{Value: true},
+			}
+
+			if tc.csr {
+				plan.CSR = types.String{Value: "-----BEGIN CERTIFICATE REQUEST-----\nMIIBAA==\n-----END CERTIFICATE REQUEST-----\n"}
+				plan.CommonName = types.String{Null: true}
+			} else {
+				plan.CSR = types.String{Null: true}
+				plan.CommonName = types.String{Value: cn}
+			}
+
+			// state carries the OLD friendly-name values that the plan is
+			// changing away from -- exactly the scenario where the pre-fix
+			// code silently ignored the plan.
+			state := plan
+			state.FriendlyName = types.String{Value: "state-old-friendly"}
+			state.UseCNAsFriendlyName = types.Bool{Value: false}
+			// State's CSR must be null regardless of branch under test so
+			// that Update's `if !state.CSR.IsNull()` subject-field override
+			// (irrelevant to this test) doesn't fire.
+			state.CSR = types.String{Null: true}
+			state.CommonName = types.String{Value: cn}
+
+			planObj := tfsdk.Plan{Schema: schema}
+			if d := planObj.Set(context.Background(), &plan); d.HasError() {
+				t.Fatalf("test setup: plan.Set returned diagnostics: %+v", d)
+			}
+			stateObj := tfsdk.State{Schema: schema}
+			if d := stateObj.Set(context.Background(), &state); d.HasError() {
+				t.Fatalf("test setup: state.Set returned diagnostics: %+v", d)
+			}
+
+			r := resourceCommandCertificate{p: provider{configured: true, client: client}}
+			req := tfsdk.UpdateResourceRequest{Plan: planObj, State: stateObj}
+			resp := &tfsdk.UpdateResourceResponse{State: tfsdk.State{Schema: schema}}
+
+			r.Update(context.Background(), req, resp)
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("Update returned diagnostics: %+v", resp.Diagnostics)
+			}
+
+			var result CommandCertificate
+			if d := resp.State.Get(context.Background(), &result); d.HasError() {
+				t.Fatalf("failed to read back updated state: %+v", d)
+			}
+
+			if result.FriendlyName.Null || result.FriendlyName.Value != "plan-friendly" {
+				t.Errorf(
+					"friendly_name after Update = %+v, want the PLAN value %q -- Update must follow "+
+						"Terraform's own plan for this Optional (not Computed) attribute, not silently "+
+						"keep serving the prior state value (this is what caused \"provider produced "+
+						"inconsistent result after apply\")",
+					result.FriendlyName, "plan-friendly",
+				)
+			}
+			if result.UseCNAsFriendlyName.Null || result.UseCNAsFriendlyName.Value != true {
+				t.Errorf(
+					"use_cn_as_friendly_name after Update = %+v, want the PLAN value true -- same "+
+						"inconsistent-result-after-apply bug class as friendly_name",
+					result.UseCNAsFriendlyName,
+				)
+			}
+		})
+	}
+}
+
+// TestUnitKeyfactorCertificateResource_ImportState_FriendlyNameFieldsNull is
+// the regression test for the companion ImportState bug: collection_id,
+// friendly_name, and use_cn_as_friendly_name were set from a freshly
+// zero-valued `state` struct (there is no prior state to import into), which
+// produced a KNOWN Go zero value (0 / "" / false) rather than an explicit
+// null. That known-zero then disagreed with the null Update() writes for
+// these write-only-equivalent attributes on the very next reconcile apply,
+// producing "provider produced inconsistent result after apply" immediately
+// after `terraform import`.
+func TestUnitKeyfactorCertificateResource_ImportState_FriendlyNameFieldsNull(t *testing.T) {
+	const certID = 845091
+	const cn = "tf-unit-friendlyname-import.example.com"
+	leaf := buildFriendlyNameTestLeaf(t, cn)
+
+	certGetResp := api.GetCertificateResponse{
+		Id:            certID,
+		IssuedCN:      cn,
+		ContentBytes:  base64.StdEncoding.EncodeToString(leaf.Raw),
+		HasPrivateKey: false, // CSR-enrollment-style path: PEM download, no PFX recovery
+	}
+	getBody, err := json.Marshal(certGetResp)
+	if err != nil {
+		t.Fatalf("marshal certGetResp: %v", err)
+	}
+	downloadBody, err := json.Marshal(map[string]string{"Content": buildRootFirstP7B(t, leaf)})
+	if err != nil {
+		t.Fatalf("marshal download body: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		switch {
+		case r.Method == http.MethodPost:
+			_, _ = w.Write(downloadBody)
+		default:
+			_, _ = w.Write(getBody)
+		}
+	})
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+
+	client := newFriendlyNameMockClient(server)
+
+	schema, sDiags := resourceCommandCertificateType{}.GetSchema(context.Background())
+	if sDiags.HasError() {
+		t.Fatalf("GetSchema returned diagnostics: %+v", sDiags)
+	}
+
+	r := resourceCommandCertificate{p: provider{configured: true, client: client}}
+	req := tfsdk.ImportResourceStateRequest{ID: "845091"}
+	resp := &tfsdk.ImportResourceStateResponse{State: tfsdk.State{Schema: schema}}
+
+	r.ImportState(context.Background(), req, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("ImportState returned diagnostics: %+v", resp.Diagnostics)
+	}
+
+	var result CommandCertificate
+	if d := resp.State.Get(context.Background(), &result); d.HasError() {
+		t.Fatalf("failed to read back imported state: %+v", d)
+	}
+
+	if !result.CollectionId.Null {
+		t.Errorf(
+			"collection_id after ImportState = %+v, want explicit null -- a known zero value here "+
+				"disagrees with the null Update() writes once config doesn't set collection_id, causing "+
+				"\"provider produced inconsistent result after apply\" on the first reconcile apply after import",
+			result.CollectionId,
+		)
+	}
+	if !result.FriendlyName.Null {
+		t.Errorf(
+			"friendly_name after ImportState = %+v, want explicit null -- same inconsistent-result-after-"+
+				"apply bug class as collection_id",
+			result.FriendlyName,
+		)
+	}
+	if !result.UseCNAsFriendlyName.Null {
+		t.Errorf(
+			"use_cn_as_friendly_name after ImportState = %+v, want explicit null -- same inconsistent-"+
+				"result-after-apply bug class as collection_id",
+			result.UseCNAsFriendlyName,
+		)
+	}
+}

--- a/terraform/k8s_orchestrator_demo/README.md
+++ b/terraform/k8s_orchestrator_demo/README.md
@@ -150,18 +150,11 @@ terraform import keyfactor_certificate_store.k8s_tls_secret "xxxxxxxx-xxxx-xxxx-
 | K8SPKCS12 | `.p12/<keystore-alias>` | Field name `.p12` set via `CertificateDataFieldName` |
 | K8SCert / K8SNS / K8SCluster | *(not applicable)* | Inventory/discovery only — Add not supported |
 
-> **TEMPORARY limitation — `tls_secret` / `opaque_secret` (K8STLSSecr / K8SSecret):**
-> The k8s-orchestrator extension's Management (Add) job for these two store types, on the
-> no-alias/"unconditional replace" code path used by this demo, reports `Result: Success`
-> in Command's JobHistory but does not actually write the new certificate into the target
-> K8s Secret (confirmed against a live lab: the Secret's `tls.crt` still held a certificate
-> enrolled 5 days earlier after a job reporting Success). Because the job falsely reports
-> success, `fail_on_job_failure` cannot catch this — it only fires on a genuine
-> failure/warning result. To avoid an indefinite hang, `deployments.tf` sets
-> `skip_inventory_validation = true` on `tls_secret` and `opaque_secret` only. This means
-> "fire and forget": `apply` goes green once the job is submitted, but does **not** verify
-> the certificate actually landed in the K8s Secret. `jks`, `jks_buddy`, `pkcs12`, and
-> `pkcs12_buddy` are unaffected and keep full inventory-based verification.
-> Tracked upstream: https://github.com/Keyfactor/k8s-orchestrator/issues/91
-> **REVERT** `skip_inventory_validation = true` on both resources once the upstream issue
-> is fixed, to restore this demo's intended end-to-end verification guarantee.
+All `keyfactor_certificate_deployment` resources in this demo, including `tls_secret` and
+`opaque_secret` (K8STLSSecr / K8SSecret), use full inventory-based verification: `apply`
+waits for the deployed certificate to appear in the target store's inventory before
+completing. Previously, `tls_secret` and `opaque_secret` required a
+`skip_inventory_validation = true` workaround because the k8s-orchestrator extension's
+Management (Add) job for these two store types silently failed to write the K8s Secret's
+data while still reporting `Result: Success` in Command's JobHistory. That bug is fixed
+upstream: https://github.com/Keyfactor/k8s-orchestrator/issues/91

--- a/terraform/k8s_orchestrator_demo/deployments.tf
+++ b/terraform/k8s_orchestrator_demo/deployments.tf
@@ -26,10 +26,13 @@ resource "keyfactor_certificate" "demo" {
 # read-only — the Add operation is not supported by this store type.
 #
 # Alias format per store type (from k8s-orchestrator docs):
-#   K8STLSSecr  — omit alias; cert is placed into the store's backing TLS
-#                 secret unconditionally. Providing an alias requires overwrite=true
-#                 AND the alias must already be tracked by Command.
-#   K8SSecret   — same as K8STLSSecr; omit alias for unconditional placement.
+#   K8STLSSecr  — alias is the backing secret's name. The k8s-orchestrator extension
+#                 requires overwrite=true whenever the backing secret already holds
+#                 data (i.e. on every redeploy after the first) and, per Command's own
+#                 validation, overwrite=true requires an alias that Command already
+#                 tracks in the store's inventory. This demo sets both explicitly so
+#                 repeated applies stay idempotent.
+#   K8SSecret   — same as K8STLSSecr.
 #   K8SJKS      — "<CertificateDataFieldName>/<keystore-alias>"
 #                 CertificateDataFieldName defaults to "jks" when not set.
 #                 Example: "jks/my-cert"
@@ -41,49 +44,29 @@ resource "keyfactor_certificate" "demo" {
 resource "keyfactor_certificate_deployment" "tls_secret" {
   certificate_id       = keyfactor_certificate.demo.certificate_id
   certificate_store_id = keyfactor_certificate_store.k8s_tls_secret.id
-  # K8STLSSecr: alias is the K8S secret name; omitting alias lets Command match by cert ID.
-  # Overwrite is required if an alias is provided but the alias already exists; without
-  # an alias the cert is placed into the store's backing secret unconditionally.
-
-  # TEMPORARY WORKAROUND — DO NOT treat as the intended long-term config.
-  # The k8s-orchestrator extension's Management (Add) job for K8STLSSecr, on the
-  # no-alias/"unconditional replace" code path used here, reports Result: Success
-  # in Command's JobHistory but does not actually write the new certificate into
-  # the target K8s Secret (confirmed against a live lab: JobHistory showed
-  # Success while the Secret's tls.crt still held a certificate enrolled 5 days
-  # earlier). Because the job falsely reports success, fail_on_job_failure cannot
-  # catch this — it only fires on a genuine failure/warning result. The only way
-  # to avoid an indefinite hang polling for inventory that will never reflect the
-  # new cert is to skip inventory validation entirely.
-  # skip_inventory_validation = true therefore means "fire and forget": apply
-  # goes green once the job is submitted (and even falsely reports success), but
-  # this does NOT confirm the certificate actually landed in the K8s Secret.
-  # Tracked upstream: https://github.com/Keyfactor/k8s-orchestrator/issues/91
-  # REVERT: remove this line once the upstream issue is fixed, to restore full
-  # inventory-based verification (the demo's actual intended behavior).
-  skip_inventory_validation = true
+  # K8STLSSecr: alias is the K8S secret name; Command already tracks "tf-demo-tls-secret"
+  # as the store's inventoried alias, so overwrite=true is required (and valid) to
+  # redeploy onto the existing backing secret.
+  certificate_alias = "tf-demo-tls-secret"
+  overwrite         = true
+  #
+  # Full inventory-based verification (the default apply behavior): the resource waits
+  # for the deployed certificate to appear in the store's inventory before completing.
+  # Previously worked around via skip_inventory_validation = true because the
+  # k8s-orchestrator extension's Management (Add) job silently failed to write the K8s
+  # Secret while still reporting Result: Success. Fixed upstream:
+  # https://github.com/Keyfactor/k8s-orchestrator/issues/91
 }
 
 resource "keyfactor_certificate_deployment" "opaque_secret" {
   certificate_id       = keyfactor_certificate.demo.certificate_id
   certificate_store_id = keyfactor_certificate_store.k8s_opaque_secret.id
-  # K8SSecret: same pattern as K8STLSSecr — alias optional, omit for unconditional placement.
-
-  # TEMPORARY WORKAROUND — DO NOT treat as the intended long-term config.
-  # Same root cause as tls_secret above: the k8s-orchestrator extension's
-  # Management (Add) job for K8SSecret, on the no-alias/"unconditional replace"
-  # code path, reports Result: Success in Command's JobHistory but does not
-  # actually write the new certificate into the target K8s Secret (confirmed
-  # against a live lab via JobHistory + direct inspection of the Secret's
-  # contents). fail_on_job_failure cannot catch this false-positive success, so
-  # skip_inventory_validation = true is used to avoid an indefinite hang.
-  # skip_inventory_validation = true means "fire and forget": apply goes green
-  # once the job is submitted (and even falsely reports success), but this does
-  # NOT confirm the certificate actually landed in the K8s Secret.
-  # Tracked upstream: https://github.com/Keyfactor/k8s-orchestrator/issues/91
-  # REVERT: remove this line once the upstream issue is fixed, to restore full
-  # inventory-based verification (the demo's actual intended behavior).
-  skip_inventory_validation = true
+  # K8SSecret: same pattern as tls_secret above.
+  certificate_alias = "tf-demo-opaque-secret"
+  overwrite         = true
+  #
+  # Full inventory-based verification (the default apply behavior) — see the tls_secret
+  # resource above; same fixed upstream issue applied to K8SSecret as well.
 }
 
 resource "keyfactor_certificate_deployment" "jks" {


### PR DESCRIPTION
Unrelated to #201 — found incidentally while validating that PR's fix against a live lab, split out per this repo's clean-PR-scope convention. Based on `feat/lab-release-harness` (66495e5), not stacked on #201.

## Bug

`friendly_name` and `use_cn_as_friendly_name` are plain `Optional` (not `Computed`) schema attributes, so Terraform's plan step has already resolved their final value directly from config before `Update()` ever runs — the provider has no discretion here. Both branches of `Update()` (non-CSR and CSR) instead hardcoded them from `state.X`, so whenever a user changed or removed either field in config relative to prior state, `Update()` silently kept serving the old state value instead of the value Terraform's own plan already computed — producing "provider produced inconsistent result after apply".

Separately, `ImportState()` set the same two fields (plus `collection_id`) from `state.X`, which during import is always a freshly zero-valued struct — so these landed as a *known* zero value (empty string / `false`) rather than an explicit null, unlike the other write-only fields in the same function that are already nulled correctly. This caused a same-apply "inconsistent result after apply" crash on the very first reconcile immediately after `terraform import`.

Confirmed live against kfclab 2026-08-16 while reconciling an imported certificate.

## Fix

- `Update()`: read `friendly_name`/`use_cn_as_friendly_name` from `plan`, not `state`.
- `ImportState()`: set `collection_id`/`friendly_name`/`use_cn_as_friendly_name` to explicit `Null: true`, matching how other not-recoverable-from-server write-only fields are already handled in this function.

## Tests

New network-free tests driving `Update()`/`ImportState()` directly against a mock Command server: `TestUnitKeyfactorCertificateResource_Update_FriendlyNameFollowsPlan` (both branches) and `TestUnitKeyfactorCertificateResource_ImportState_FriendlyNameFieldsNull`. Confirmed red against the unfixed code, green after.

Full `TestUnit*` suite green (494s).
